### PR TITLE
Add footer attribution text to AnalyzerPage

### DIFF
--- a/src/ui/pages/AnalyzerPage.test.tsx
+++ b/src/ui/pages/AnalyzerPage.test.tsx
@@ -86,4 +86,10 @@ describe('AnalyzerPage', () => {
     expect(args[1]).toBe(true);
     expect(args[3]).toBe('es');
   });
+
+  it('shows footer credit text', () => {
+    render(<AnalyzerPage />);
+
+    expect(screen.getByText('Made with 💙 by arrf')).toBeTruthy();
+  });
 });

--- a/src/ui/pages/AnalyzerPage.tsx
+++ b/src/ui/pages/AnalyzerPage.tsx
@@ -183,6 +183,7 @@ export function AnalyzerPage() {
           dangerouslySetInnerHTML={{ __html: dashboardHtml }}
         />
       )}
+      <footer className="app-footer">Made with 💙 by arrf</footer>
     </>
   );
 }

--- a/src/ui/styles/global.css
+++ b/src/ui/styles/global.css
@@ -152,6 +152,13 @@ body {
   font-size: 0.85rem;
 }
 
+.app-footer {
+  padding: 0 1.5rem 1.25rem;
+  text-align: center;
+  color: var(--text-dim);
+  font-size: 0.85rem;
+}
+
 /* DASHBOARD */
 #dashboard {
   display: none;


### PR DESCRIPTION
### Motivation
- Add a persistent small attribution in the app UI so users see the credit message "Made with 💙 by arrf" in the footer.

### Description
- Inserted a `<footer className="app-footer">Made with 💙 by arrf</footer>` into `AnalyzerPage` and added corresponding `.app-footer` styles in `src/ui/styles/global.css`.

### Testing
- Installed dependencies with `npm install` and ran the component tests with `npm test -- src/ui/pages/AnalyzerPage.test.tsx`, and the test suite passed (`3 tests` all green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd65f2d00832094a8937d5ccaa454)