### PR TITLE
Add AAPL demo loader to landing page and switch title typography

### DIFF
--- a/src/domain/i18n/en.ts
+++ b/src/domain/i18n/en.ts
@@ -7,6 +7,7 @@ export const I18N = {
     language: 'Idioma',
     industry: 'Industria GICS',
     analyze: 'Analizar Financieros',
+    loadDemoData: 'Modo prueba (AAPL)',
     includeAnalystNoise: 'Incluir ruido de analistas en el resumen',
     customProfileHint:
       'El perfil personalizado sobreescribe solo los umbrales activos.',
@@ -42,6 +43,7 @@ export const I18N = {
     language: 'Language',
     industry: 'GICS Industry',
     analyze: 'Analyze Financials',
+    loadDemoData: 'Demo mode (AAPL)',
     includeAnalystNoise: 'Include analyst noise in summary',
     customProfileHint: 'Custom profile overrides active thresholds only.',
     dataPlaceholder:

--- a/src/raw-modules.d.ts
+++ b/src/raw-modules.d.ts
@@ -1,0 +1,4 @@
+declare module '*.md?raw' {
+  const content: string;
+  export default content;
+}

--- a/src/ui/pages/AnalyzerPage.test.tsx
+++ b/src/ui/pages/AnalyzerPage.test.tsx
@@ -42,6 +42,11 @@ vi.mock('../../domain/metrics/scoring', () => ({
   updateToggleSectionsButton: vi.fn()
 }));
 
+
+vi.mock('../../../test-data/apple.md?raw', () => ({
+  default: 'APPLE DEMO CONTENT'
+}));
+
 import { AnalyzerPage } from './AnalyzerPage';
 
 describe('AnalyzerPage', () => {
@@ -69,6 +74,16 @@ describe('AnalyzerPage', () => {
     );
     expect(options).toHaveLength(1);
     expect(options[0].textContent).toContain('Banks');
+  });
+
+
+  it('loads demo data into the textarea', () => {
+    render(<AnalyzerPage />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'loadDemoData' }));
+
+    const textarea = screen.getByPlaceholderText('dataPlaceholder') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('APPLE DEMO CONTENT');
   });
 
   it('calls analyze with selected controls', () => {

--- a/src/ui/pages/AnalyzerPage.tsx
+++ b/src/ui/pages/AnalyzerPage.tsx
@@ -8,6 +8,7 @@ import {
 } from '../../domain/metrics/scoring';
 import { useAnalyzer } from '../hooks/useAnalyzer';
 import { useI18n } from '../hooks/useI18n';
+import appleTestData from '../../../test-data/apple.md?raw';
 
 export function AnalyzerPage() {
   const { lang, t, changeLanguage } = useI18n();
@@ -158,14 +159,22 @@ export function AnalyzerPage() {
               </label>
             </div>
             <div style={{ display: 'flex', justifyContent: 'center' }}>
-              <button
-                className="btn-analyze"
-                onClick={() =>
-                  analyze(raw, includeAnalystNoise, industry, lang)
-                }
-              >
-                {t('analyze')}
-              </button>
+              <div className="landing-actions">
+                <button
+                  className="btn-secondary"
+                  onClick={() => setRaw(appleTestData)}
+                >
+                  {t('loadDemoData')}
+                </button>
+                <button
+                  className="btn-analyze"
+                  onClick={() =>
+                    analyze(raw, includeAnalystNoise, industry, lang)
+                  }
+                >
+                  {t('analyze')}
+                </button>
+              </div>
             </div>
             {error ? (
               <div id="error-msg" style={{ display: 'block' }}>

--- a/src/ui/styles/global.css
+++ b/src/ui/styles/global.css
@@ -71,7 +71,7 @@ body {
   );
 }
 #landing h1 {
-  font-family: 'Playfair Display', serif;
+  font-family: Consolas, 'JetBrains Mono', 'Courier New', monospace;
   font-weight: 900;
   font-size: clamp(2rem, 5vw, 3.5rem);
   text-align: center;
@@ -136,6 +136,35 @@ body {
 .btn-analyze:active {
   transform: translateY(0);
 }
+
+.landing-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.btn-secondary {
+  margin-top: 1.25rem;
+  padding: 0.85rem 1.25rem;
+  background: var(--surface2);
+  color: var(--text);
+  font-weight: 700;
+  font-size: 0.92rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.btn-secondary:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  transform: translateY(-2px);
+}
+.btn-secondary:active {
+  transform: translateY(0);
+}
 #error-msg {
   color: var(--red);
   margin-top: 0.75rem;
@@ -177,7 +206,7 @@ body {
   border-bottom: 1px solid var(--border);
 }
 .dash-header h2 {
-  font-family: 'Playfair Display', serif;
+  font-family: Consolas, 'JetBrains Mono', 'Courier New', monospace;
   font-weight: 900;
   font-size: clamp(1.5rem, 3vw, 2.2rem);
   background: linear-gradient(135deg, #e2e8f0, #38bdf8);

--- a/styles.css
+++ b/styles.css
@@ -71,7 +71,7 @@ body {
   );
 }
 #landing h1 {
-  font-family: 'Playfair Display', serif;
+  font-family: Consolas, 'JetBrains Mono', 'Courier New', monospace;
   font-weight: 900;
   font-size: clamp(2rem, 5vw, 3.5rem);
   text-align: center;
@@ -136,6 +136,35 @@ body {
 .btn-analyze:active {
   transform: translateY(0);
 }
+
+.landing-actions {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.btn-secondary {
+  margin-top: 1.25rem;
+  padding: 0.85rem 1.25rem;
+  background: var(--surface2);
+  color: var(--text);
+  font-weight: 700;
+  font-size: 0.92rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+.btn-secondary:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  transform: translateY(-2px);
+}
+.btn-secondary:active {
+  transform: translateY(0);
+}
 #error-msg {
   color: var(--red);
   margin-top: 0.75rem;
@@ -170,7 +199,7 @@ body {
   border-bottom: 1px solid var(--border);
 }
 .dash-header h2 {
-  font-family: 'Playfair Display', serif;
+  font-family: Consolas, 'JetBrains Mono', 'Courier New', monospace;
   font-weight: 900;
   font-size: clamp(1.5rem, 3vw, 2.2rem);
   background: linear-gradient(135deg, #e2e8f0, #38bdf8);


### PR DESCRIPTION
### Motivation
- Provide a quick, reproducible sample (AAPL) to load into the landing textarea so features can be tested without copying data manually. 
- Give titles a more “terminal/computer” look by using a Consolas-based monospace stack instead of Playfair Display. 
- Avoid TypeScript build errors when importing raw markdown and ensure the demo flow is covered by tests.

### Description
- Replaced `font-family: 'Playfair Display'` with `font-family: Consolas, 'JetBrains Mono', 'Courier New', monospace;` for landing and dashboard headings in `src/ui/styles/global.css` and `styles.css`. 
- Added a demo loader button to the landing page that imports `test-data/apple.md` as raw text and sets the main textarea value, implemented in `src/ui/pages/AnalyzerPage.tsx` via `import appleTestData from '../../../test-data/apple.md?raw';`. 
- Added UI layout and styles for the secondary demo button (`.landing-actions`, `.btn-secondary`) in the global styles. 
- Added i18n entries `loadDemoData` in `src/domain/i18n/en.ts` for ES/EN labels. 
- Added `src/raw-modules.d.ts` to declare `*.md?raw` module types to satisfy TypeScript. 
- Updated `src/ui/pages/AnalyzerPage.test.tsx` to mock the raw markdown module and include a test that verifies clicking the demo button fills the textarea.

### Testing
- Ran unit tests with `npm test -- --run` and all tests passed: 11 test files, 23 tests passed. 
- Ran lint with `npm run lint` which completed successfully. 
- Built the production bundle with `npm run build` which completed successfully and produced the `dist` output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cdc3ef9e88320bf3ff0aa0e23503f)