### PR TITLE
Add empty industry option to selector

### DIFF
--- a/src/ui/pages/AnalyzerPage.test.tsx
+++ b/src/ui/pages/AnalyzerPage.test.tsx
@@ -72,8 +72,18 @@ describe('AnalyzerPage', () => {
     const options = within(industrySelect as HTMLElement).getAllByRole(
       'option'
     );
-    expect(options).toHaveLength(1);
-    expect(options[0].textContent).toContain('Banks');
+    expect(options).toHaveLength(2);
+    expect(options[0].textContent).toContain('-- Ninguna --');
+    expect(options[1].textContent).toContain('Banks');
+  });
+
+  it('uses no industry as default selection', () => {
+    render(<AnalyzerPage />);
+
+    const industrySelect = document.getElementById(
+      'industrySelect'
+    ) as HTMLSelectElement;
+    expect(industrySelect.value).toBe('');
   });
 
 
@@ -99,6 +109,7 @@ describe('AnalyzerPage', () => {
     const args = analyzeSpy.mock.calls[0];
     expect(args[0]).toHaveLength(130);
     expect(args[1]).toBe(true);
+    expect(args[2]).toBe('');
     expect(args[3]).toBe('es');
   });
 

--- a/src/ui/pages/AnalyzerPage.tsx
+++ b/src/ui/pages/AnalyzerPage.tsx
@@ -18,7 +18,7 @@ export function AnalyzerPage() {
     () => [...GICS_INDUSTRIES].sort((a, b) => a.name.localeCompare(b.name)),
     []
   );
-  const [industry, setIndustry] = useState(sortedIndustries[0]?.code ?? '');
+  const [industry, setIndustry] = useState('');
   const [industryQuery, setIndustryQuery] = useState('');
   const [includeAnalystNoise, setIncludeAnalystNoise] = useState(false);
 
@@ -33,7 +33,7 @@ export function AnalyzerPage() {
   }, [industryQuery, sortedIndustries]);
 
   useEffect(() => {
-    if (filteredIndustries.length > 0) {
+    if (industry && filteredIndustries.length > 0) {
       const selectedStillVisible = filteredIndustries.some(
         (item) => item.code === industry
       );
@@ -125,6 +125,9 @@ export function AnalyzerPage() {
                 value={industry}
                 onChange={(e) => setIndustry(e.target.value)}
               >
+                <option value="">
+                  {lang === 'es' ? '-- Ninguna --' : '-- None --'}
+                </option>
                 {filteredIndustries.map((item) => (
                   <option
                     key={item.code}


### PR DESCRIPTION
### Motivation
- Allow users to explicitly choose no industry so the analyzer doesn't auto-select the first industry when none is intended.

### Description
- Initialize the `industry` state to `''` in `src/ui/pages/AnalyzerPage.tsx` instead of defaulting to the first sorted industry.
- Add a leading `<option value="">` that renders `-- Ninguna --` or `-- None --` depending on the locale in the `industrySelect` dropdown.
- Change the filtering persistence effect to only auto-select a visible industry when a real industry is currently selected (i.e. skip auto-selection when the value is empty).
- Update `src/ui/pages/AnalyzerPage.test.tsx` to expect the new empty option, verify the default selection is empty, and assert `analyze` is called with an empty industry by default.

### Testing
- Ran `npm test -- --run` and all tests passed (11 test files, 28 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ce8c9d0ac8320aad085cfbb6e8116)