### PR TITLE
refactor(domain): extract localization concerns from scoring module

### DIFF
--- a/src/domain/metrics/scoring.ts
+++ b/src/domain/metrics/scoring.ts
@@ -3,8 +3,6 @@ import {
   canonicalizeFinancialLabel,
   localizeDynamicText,
   normalizeLabelText,
-  renderMetricDetail,
-  renderPrintableMetricDetail
 } from './scoringLocalization';
 
 import {
@@ -13,6 +11,7 @@ import {
   toggleSectionUi,
   updateToggleSectionsButtonUi
 } from './scoringDashboardUi';
+import { renderDashboardView } from './scoringDashboardRender';
 const STORAGE_KEY = 'fundamentalAnalyzerLang';
 const DEFAULT_LANG = 'es';
 
@@ -5839,256 +5838,13 @@ export function analyze(data, profile = 'default', options = {}) {
 // =========================================================
 // RENDERER
 // =========================================================
-function gradeLabel(g) {
-  return (
-    {
-      excellent: t('excellent', 'Excellent'),
-      good: t('good', 'Good'),
-      average: t('average', 'Average'),
-      poor: t('poor', 'Poor'),
-      info: t('info', 'Info')
-    }[g] || g
-  );
-}
-function gradeBadgeClass(g) {
-  return (
-    {
-      excellent: 'badge-green',
-      good: 'badge-blue',
-      average: 'badge-yellow',
-      poor: 'badge-red',
-      info: 'badge-purple'
-    }[g] || 'badge-blue'
-  );
-}
-function gradeEmoji(g) {
-  return { excellent: '🟢', good: '🔵', average: '🟡', poor: '🔴' }[g] || '⚪';
-}
-
-function escapeHtml(value) {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function buildPrintableDashboardPanel(data, results, industrySelection = null) {
-  const sectionBlocks = (results.sections || [])
-    .map((section) => {
-      const sectionTitle = `${section.icon || '•'} ${localizeDynamicText(section.title || '', currentLang)}`;
-      const metrics = (section.items || [])
-        .map((item) => {
-          const metricName = localizeDynamicText(item.name || 'Metric', currentLang);
-          const signalText = localizeDynamicText(item.signalText || '', currentLang);
-          const signal =
-            item.signal === 'bull'
-              ? currentLang === 'es'
-                ? '🟢 Positiva'
-                : '🟢 Positive'
-              : item.signal === 'bear'
-                ? currentLang === 'es'
-                  ? '🔴 Negativa'
-                  : '🔴 Negative'
-                : currentLang === 'es'
-                  ? '🟡 Neutral'
-                  : '🟡 Neutral';
-          const note = localizeDynamicText(item.note || '', currentLang);
-          const { headline, bulletHtml } = renderPrintableMetricDetail(item, currentLang, escapeHtml);
-          return `<li class="print-metric">
-            <div class="print-title">${escapeHtml(metricName)}</div>
-            ${headline ? `<div class="print-headline">${escapeHtml(headline)}</div>` : ''}
-            <ul class="print-bullets">${bulletHtml}</ul>
-            <div class="print-signal"><strong>${escapeHtml(currentLang === 'es' ? 'Señal:' : 'Signal:')}</strong> ${escapeHtml(signal)}${signalText ? ` · ${escapeHtml(signalText)}` : ''}</div>
-            ${note ? `<div class="print-note">${escapeHtml(note)}</div>` : ''}
-          </li>`;
-        })
-        .join('');
-      return `<section><h3>${escapeHtml(sectionTitle)}</h3><ul class="print-metrics">${metrics}</ul></section>`;
-    })
-    .join('');
-
-  const scoreLine = `${currentLang === 'es' ? 'Puntuación global' : 'Overall score'}: ${results.overallScore?.toFixed(1) || '-'} / 4.0`;
-  const industryLine = industrySelection
-    ? `${industrySelection.code} · ${industrySelection.name} (${industrySelection.profile})`
-    : currentLang === 'es'
-      ? 'Sin industria seleccionada'
-      : 'No selected industry';
-
-  return `<div class="printable-panel fade-up">
-    <div class="printable-header">
-      <h2>${escapeHtml(data.ticker ? `${data.ticker} — ${data.company}` : data.company)}</h2>
-      <p>${escapeHtml(data.period || '')}</p>
-      <p class="printable-help">${currentLang === 'es' ? 'Vista simplificada para imprimir. Puedes usar la impresión del navegador (Ctrl/Cmd+P).' : 'Simplified print-friendly view. Use your browser print dialog (Ctrl/Cmd+P).'}</p>
-    </div>
-    <div class="printable-summary">
-      <h3>${currentLang === 'es' ? 'Resumen rápido' : 'Quick summary'}</h3>
-      <p>${escapeHtml(scoreLine)}</p>
-      <p>${escapeHtml(currentLang === 'es' ? 'Industria:' : 'Industry:')} ${escapeHtml(industryLine)}</p>
-      <p>${escapeHtml(currentLang === 'es' ? `Métricas analizadas: ${results.totalMetrics}` : `Analyzed metrics: ${results.totalMetrics}`)}</p>
-    </div>
-    ${sectionBlocks}
-  </div>`;
-}
-
-function renderTrendBars(values, labels = []) {
-  const series = Array.isArray(values) ? values : [];
-  const points = Math.max(series.length, labels.length);
-  if (!points) return '';
-
-  const numeric = series.filter(
-    (v) => v !== null && v !== undefined && !isNaN(v)
-  );
-  const max = Math.max(...numeric.map((v) => Math.abs(v)), 1);
-  return `<div class="trend-bar">${Array.from({ length: points }, (_, i) => {
-      const v = series[i];
-      if (v === null || v === undefined || isNaN(v))
-        return '<div class="bar bar-missing"></div>';
-      const h = Math.max(2, (Math.abs(v) / max) * 30);
-      const cls = v > 0 ? 'bar-pos' : v < 0 ? 'bar-neg' : 'bar-zero';
-      const year = labels[i] || `#${i + 1}`;
-      const label = `${year}: ${v.toFixed(2)}`;
-      return `<button type="button" class="bar ${cls}" style="height:${h}px" title="${label}" aria-label="${label}" data-point="${label}"></button>`;
-    })
-    .join(
-      ''
-    )}</div>`;
-}
-
 export function renderDashboard(data, results, industrySelection: { code: string; name: string; profile: string } | null = null) {
-  const overallLabel = gradeLabel(results.overall || 'average');
-
-  let html = `
-    <div class="dash-header fade-up">
-      <div>
-        <h2>${data.ticker ? data.ticker + ' — ' : ''}${data.company}</h2>
-        <span class="price">${data.price || ''} ${data.period ? '• ' + localizeDynamicText(data.period, currentLang) : ''} • ${results.totalMetrics} ${t('metricsAnalyzed', 'metrics analyzed')}</span>
-      </div>
-      <div class="header-actions">
-        <button class="btn-toggle-sections" onclick="switchDashboardTab('print')">${currentLang === 'es' ? '🖨️ Imprimir' : '🖨️ Print'}</button>
-        <button id="toggleSectionsBtn" class="btn-toggle-sections" onclick="toggleAllSections()">${t('collapseAll', 'Collapse all sections')}</button>
-        <button class="btn-back" onclick="goBack()">${t('newAnalysis', '← New Analysis')}</button>
-      </div>
-    </div>
-    <div class="dashboard-tabs fade-up">
-      <button class="dashboard-tab active" data-tab="analysis" onclick="switchDashboardTab('analysis')">${currentLang === 'es' ? 'Análisis' : 'Analysis'}</button>
-      <button class="dashboard-tab" data-tab="industry" onclick="switchDashboardTab('industry')">${currentLang === 'es' ? 'KPIs por industria' : 'Industry KPIs'}</button>
-      <button class="dashboard-tab" data-tab="print" onclick="switchDashboardTab('print')">${currentLang === 'es' ? '🖨️ Imprimible' : '🖨️ Printable'}</button>
-    </div>
-    <div class="dashboard-panel" data-panel="analysis">
-  `;
-
-  const byId = (id) => results.sections.find((s) => s.id === id);
-  const catDefs = [
-    {
-      k: 'Quality',
-      sec: ['harmony', 'cashflow-truth', 'margins', 'cashflow'],
-      href: '#harmony'
-    },
-    { k: 'Moat', sec: ['moat', 'margins'], href: '#moat' },
-    {
-      k: 'Financial Risk',
-      sec: ['balance', 'balance-composition', 'debt'],
-      href: '#balance'
-    },
-    {
-      k: 'Valuation',
-      sec: ['valuation', 'valuation-philosophy'],
-      href: '#valuation-philosophy'
-    }
-  ];
-  html += `<div class="score-row">`;
-  catDefs.forEach((cat) => {
-    const found = cat.sec.map(byId).filter(Boolean);
-    const signals = found.flatMap((f) => f.items || []);
-    const bears = signals.filter((i) => i.signal === 'bear').length;
-    const bulls = signals.filter((i) => i.signal === 'bull').length;
-    const grade = bears >= 2 ? 'poor' : bulls > bears ? 'good' : 'average';
-    const driver = localizeDynamicText(signals[0]?.name || 'Not enough data', currentLang);
-    const light = grade === 'poor' ? '🔴' : grade === 'good' ? '🟢' : '🟡';
-    html += `<div class="score-card ${grade} fade-up"><div class="label">${localizeDynamicText(`2-minute ${cat.k}`, currentLang)}</div><div class="value">${light} ${gradeLabel(grade)}</div><div class="detail">${driver} · <a href="${cat.href}" style="color:var(--accent)">${localizeDynamicText('see details', currentLang)}</a></div></div>`;
+  return renderDashboardView(data, results, industrySelection, {
+    lang: currentLang,
+    t,
+    buildSummary,
+    buildIndustryPanel
   });
-  html += `</div>`;
-
-  const cards = [
-    {
-      label: localizeDynamicText('Overall Health', currentLang),
-      value: overallLabel,
-      grade: results.overall,
-      detail: `${currentLang === 'es' ? 'Puntuación' : 'Score'}: ${results.overallScore?.toFixed(1)}/4.0`
-    },
-    ...Object.entries(results.scores).map(([k, g]) => ({
-      label: localizeDynamicText(k.charAt(0).toUpperCase() + k.slice(1), currentLang),
-      value: gradeEmoji(g) + ' ' + gradeLabel(g),
-      grade: g,
-      detail: ''
-    }))
-  ];
-
-  html += `<div class="score-row">`;
-  cards.forEach((c, i) => {
-    html += `<div class="score-card ${c.grade} fade-up delay-${Math.min(i + 1, 6)}">
-      <div class="label">${c.label}</div>
-      <div class="value">${c.value}</div>
-      ${c.detail ? `<div class="detail">${c.detail}</div>` : ''}
-    </div>`;
-  });
-  html += `</div>`;
-
-  results.sections.forEach((sec, si) => {
-    const badgeCls = gradeBadgeClass(sec.grade);
-    html += `
-    <div id="${sec.id || `sec-${si}`}" class="section fade-up delay-${Math.min(si + 2, 6)}">
-      <div class="section-head${si < 4 ? ' open' : ''}" onclick="toggleSection(this)">
-        <span style="font-size:1.2rem">${sec.icon}</span>
-        <h3>${localizeDynamicText(sec.title, currentLang)}</h3>
-        <span class="metric-count">${sec.items.length} ${t('metricsAnalyzed', 'metrics analyzed')}</span>
-        <span class="badge ${badgeCls}">${gradeLabel(sec.grade)}</span>
-        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
-      </div>
-      <div class="section-body">
-        <div class="analysis-grid">
-    `;
-    sec.items.forEach((item) => {
-      const sigCls =
-        item.signal === 'bull'
-          ? 'signal-bull'
-          : item.signal === 'bear'
-            ? 'signal-bear'
-            : item.signal === 'info'
-              ? 'signal-info'
-              : 'signal-neutral';
-      const dotCls =
-        item.signal === 'bull'
-          ? 'dot-green'
-          : item.signal === 'bear'
-            ? 'dot-red'
-            : item.signal === 'info'
-              ? 'dot-blue'
-              : 'dot-yellow';
-      html += `
-        <div class="a-item">
-          <div>
-            <div class="metric-name">${localizeDynamicText(item.name, currentLang)}${item.tip ? ` <span class="tip" data-tip="${localizeDynamicText(item.tip, currentLang)}">ⓘ</span>` : ''} <span class="tip" data-tip="${t('scoreConditions', 'Score conditions')}: ${localizeDynamicText(item.scoreRule || item.explanation || item.signalText || '', currentLang)}">🏷️</span></div>
-            ${renderMetricDetail(item.detail || '', currentLang)}
-            ${item.explanation ? `<div class="metric-values">${localizeDynamicText(item.explanation, currentLang)}</div>` : ''}
-            <div class="metric-values">${t('confidence', 'Confidence')}: ${(item.confidence * 100).toFixed(0)}%</div>
-            ${renderTrendBars(item.values?.fullValues || item.values, item.values?.fullLabels || item.labels || [])}
-          </div>
-          <div class="signal ${sigCls}">
-            <span class="dot ${dotCls}"></span>
-            ${localizeDynamicText(item.signalText, currentLang)}
-          </div>
-        </div>
-      `;
-    });
-    html += `</div></div></div>`;
-  });
-
-  html += buildSummary(data, results);
-  html += `</div><div class="dashboard-panel" data-panel="industry" style="display:none">${buildIndustryPanel(data, results, industrySelection)}</div><div class="dashboard-panel" data-panel="print" style="display:none">${buildPrintableDashboardPanel(data, results, industrySelection)}</div>`;
-  return html;
 }
 
 export function updateToggleSectionsButton() {
@@ -6147,10 +5903,10 @@ function buildSummary(data, results) {
   <div class="summary-box fade-up delay-6">
     <h4>📋 ${currentLang === 'es' ? 'Resumen del Análisis' : 'Analysis Summary'} — ${data.ticker || data.company}</h4>
     <p style="margin-bottom:.5rem"><strong>${currentLang === 'es' ? 'Veredicto de armonía' : 'Harmony verdict'}:</strong> ${harmonyVerdict}</p>
-    <p><strong style="color:var(--green)">${currentLang === 'es' ? 'Fortalezas principales (3)' : 'Top strengths (3)'}:</strong> ${strengths.length ? strengths.slice(0, 3).map(localizeDynamicText).join(' · ') : currentLang === 'es' ? 'No se identificaron con los datos disponibles.' : 'None identified from available data.'}</p>
-    <p style="margin-top:.45rem"><strong style="color:var(--red)">${currentLang === 'es' ? 'Riesgos principales (3)' : 'Top risks (3)'}:</strong> ${risks.length ? risks.slice(0, 3).map(localizeDynamicText).join(' · ') : currentLang === 'es' ? 'No se detectaron banderas rojas relevantes.' : 'No major red flags detected.'}</p>
-    <p style="margin-top:.45rem"><strong>${currentLang === 'es' ? 'Señales de alta confianza' : 'High confidence signals'}:</strong> ${highConfidence.slice(0, 6).map(localizeDynamicText).join(' · ') || (currentLang === 'es' ? 'Limitado' : 'Limited')}</p>
-    <p style="margin-top:.35rem"><strong>${currentLang === 'es' ? 'Baja confianza / faltan datos' : 'Low confidence / missing data'}:</strong> ${lowConfidence.slice(0, 6).map(localizeDynamicText).join(' · ') || (currentLang === 'es' ? 'Mínimo' : 'Minimal')}</p>
+    <p><strong style="color:var(--green)">${currentLang === 'es' ? 'Fortalezas principales (3)' : 'Top strengths (3)'}:</strong> ${strengths.length ? strengths.slice(0, 3).map((text) => localizeDynamicText(text, currentLang)).join(' · ') : currentLang === 'es' ? 'No se identificaron con los datos disponibles.' : 'None identified from available data.'}</p>
+    <p style="margin-top:.45rem"><strong style="color:var(--red)">${currentLang === 'es' ? 'Riesgos principales (3)' : 'Top risks (3)'}:</strong> ${risks.length ? risks.slice(0, 3).map((text) => localizeDynamicText(text, currentLang)).join(' · ') : currentLang === 'es' ? 'No se detectaron banderas rojas relevantes.' : 'No major red flags detected.'}</p>
+    <p style="margin-top:.45rem"><strong>${currentLang === 'es' ? 'Señales de alta confianza' : 'High confidence signals'}:</strong> ${highConfidence.slice(0, 6).map((text) => localizeDynamicText(text, currentLang)).join(' · ') || (currentLang === 'es' ? 'Limitado' : 'Limited')}</p>
+    <p style="margin-top:.35rem"><strong>${currentLang === 'es' ? 'Baja confianza / faltan datos' : 'Low confidence / missing data'}:</strong> ${lowConfidence.slice(0, 6).map((text) => localizeDynamicText(text, currentLang)).join(' · ') || (currentLang === 'es' ? 'Mínimo' : 'Minimal')}</p>
     <p style="margin-top:.75rem;font-size:.78rem;color:var(--text-dim)">
       ${currentLang === 'es' ? '⚠️ Herramienta de cribado. Usa siempre los informes primarios y tu propia diligencia debida.' : '⚠️ Screening tool only. Use primary filings and your own due diligence.'}
     </p>

--- a/src/domain/metrics/scoring.ts
+++ b/src/domain/metrics/scoring.ts
@@ -1,3 +1,4 @@
+// @ts-nocheck
 import {
   canonicalizeFinancialLabel,
   localizeDynamicText,
@@ -6,7 +7,6 @@ import {
   renderPrintableMetricDetail
 } from './scoringLocalization';
 
-// @ts-nocheck
 const STORAGE_KEY = 'fundamentalAnalyzerLang';
 const DEFAULT_LANG = 'es';
 
@@ -5950,7 +5950,7 @@ function renderTrendBars(values, labels = []) {
     )}</div>`;
 }
 
-export function renderDashboard(data, results, industrySelection = null) {
+export function renderDashboard(data, results, industrySelection: { code: string; name: string; profile: string } | null = null) {
   const overallLabel = gradeLabel(results.overall || 'average');
 
   let html = `
@@ -6330,36 +6330,45 @@ export function switchDashboardTab(tab) {
 // MAIN
 // =========================================================
 function showDashboard() {
-  document.getElementById('landing').style.display = 'none';
-  const d = document.getElementById('dashboard');
-  d.style.display = 'block';
+  const landing = document.getElementById('landing');
+  const dashboard = document.getElementById('dashboard');
+  if (!landing || !dashboard) return;
+  landing.style.display = 'none';
+  dashboard.style.display = 'block';
   window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
 function showLanding() {
-  document.getElementById('dashboard').style.display = 'none';
-  document.getElementById('landing').style.display = 'flex';
+  const landing = document.getElementById('landing');
+  const dashboard = document.getElementById('dashboard');
+  if (!landing || !dashboard) return;
+  dashboard.style.display = 'none';
+  landing.style.display = 'flex';
   window.scrollTo({ top: 0, behavior: 'smooth' });
 }
 
-function goBack() {
+export function goBack() {
   // optional: keep previous pasted text; if you want to clear it, uncomment next line
   // document.getElementById('dataInput').value = '';
-  document.getElementById('dashboard').innerHTML = '';
+  const dashboard = document.getElementById('dashboard');
+  if (dashboard) dashboard.innerHTML = '';
   showLanding();
 }
 
 // Profile UI toggle
-function syncCustomProfileUI() {
-  const sel = document.getElementById('profileSelect');
+export function syncCustomProfileUI() {
+  const sel = document.getElementById('profileSelect') as HTMLSelectElement | null;
   const wrap = document.getElementById('customProfileWrap');
   if (!sel || !wrap) return;
   wrap.style.display = sel.value === 'custom' ? 'block' : 'none';
 }
 
-function analyzeData() {
-  const raw = document.getElementById('dataInput').value.trim();
+export function analyzeData() {
+  const inputEl = document.getElementById('dataInput') as HTMLTextAreaElement | null;
   const errEl = document.getElementById('error-msg');
+  if (!inputEl || !errEl) return;
+
+  const raw = inputEl.value.trim();
   errEl.style.display = 'none';
   errEl.textContent = '';
 
@@ -6377,10 +6386,8 @@ function analyzeData() {
 
     // Basic sanity: did we actually parse any table rows?
     const secCount = Object.keys(data.sections || {}).length;
-    const rowCount = Object.values(data.sections || {}).reduce(
-      (s, sec) => s + (sec?.rows?.length || 0),
-      0
-    );
+    const sections = Object.values(data.sections || {}) as Array<{ rows?: unknown[] }>;
+    const rowCount = sections.reduce((s, sec) => s + (sec?.rows?.length || 0), 0);
 
     if (secCount === 0 || rowCount === 0) {
       errEl.textContent =
@@ -6391,7 +6398,9 @@ function analyzeData() {
       return;
     }
 
-    const selected = document.getElementById('profileSelect').value;
+    const selected = (
+      document.getElementById('profileSelect') as HTMLSelectElement | null
+    )?.value || 'default';
 
     let customThresholds = null;
     let engineProfile = selected;
@@ -6423,3 +6432,4 @@ function analyzeData() {
     errEl.style.display = 'block';
   }
 }
+

--- a/src/domain/metrics/scoring.ts
+++ b/src/domain/metrics/scoring.ts
@@ -7,6 +7,12 @@ import {
   renderPrintableMetricDetail
 } from './scoringLocalization';
 
+import {
+  switchDashboardTabUi,
+  toggleAllSectionsUi,
+  toggleSectionUi,
+  updateToggleSectionsButtonUi
+} from './scoringDashboardUi';
 const STORAGE_KEY = 'fundamentalAnalyzerLang';
 const DEFAULT_LANG = 'es';
 
@@ -6086,30 +6092,18 @@ export function renderDashboard(data, results, industrySelection: { code: string
 }
 
 export function updateToggleSectionsButton() {
-  const btn = document.getElementById('toggleSectionsBtn');
-  if (!btn) return;
-  const heads = Array.from(document.querySelectorAll('.section-head'));
-  if (!heads.length) {
-    btn.textContent = t('openAll', 'Open all sections');
-    return;
-  }
-  const allOpen = heads.every((h) => h.classList.contains('open'));
-  btn.textContent = allOpen
-    ? t('collapseAll', 'Collapse all sections')
-    : t('openAll', 'Open all sections');
+  updateToggleSectionsButtonUi(
+    t('collapseAll', 'Collapse all sections'),
+    t('openAll', 'Open all sections')
+  );
 }
 
 export function toggleSection(headEl) {
-  headEl.classList.toggle('open');
-  updateToggleSectionsButton();
+  toggleSectionUi(headEl, updateToggleSectionsButton);
 }
 
 export function toggleAllSections() {
-  const heads = Array.from(document.querySelectorAll('.section-head'));
-  if (!heads.length) return;
-  const allOpen = heads.every((h) => h.classList.contains('open'));
-  heads.forEach((h) => h.classList.toggle('open', !allOpen));
-  updateToggleSectionsButton();
+  toggleAllSectionsUi(updateToggleSectionsButton);
 }
 
 function buildSummary(data, results) {
@@ -6318,12 +6312,7 @@ function buildIndustryPanel(data, results, industry) {
 }
 
 export function switchDashboardTab(tab) {
-  document
-    .querySelectorAll('.dashboard-tab')
-    .forEach((btn) => btn.classList.toggle('active', btn.dataset.tab === tab));
-  document.querySelectorAll('.dashboard-panel').forEach((panel) => {
-    panel.style.display = panel.dataset.panel === tab ? 'block' : 'none';
-  });
+  switchDashboardTabUi(tab);
 }
 
 // =========================================================

--- a/src/domain/metrics/scoring.ts
+++ b/src/domain/metrics/scoring.ts
@@ -1,3 +1,11 @@
+import {
+  canonicalizeFinancialLabel,
+  localizeDynamicText,
+  normalizeLabelText,
+  renderMetricDetail,
+  renderPrintableMetricDetail
+} from './scoringLocalization';
+
 // @ts-nocheck
 const STORAGE_KEY = 'fundamentalAnalyzerLang';
 const DEFAULT_LANG = 'es';
@@ -73,735 +81,6 @@ export function setLanguage(lang) {
   const langSel = document.getElementById('langSelect');
   if (langSel) langSel.value = currentLang;
   emitLangChange();
-}
-
-const FINANCIAL_LABEL_EN_ES = {
-  Revenues: 'Ingresos',
-  'Total Revenues': 'Ingresos totales',
-  '% Change YoY': '% De cambio interanual',
-  'Cost of Goods Sold': 'Coste de los bienes vendidos',
-  'Gross Profit': 'Beneficio bruto',
-  '% Gross Margins': '% Márgenes brutos',
-  'Selling General & Admin Expenses':
-    'Gastos de venta generales y administrativos',
-  'Depreciation & Amortization': 'Depreciación y amortización',
-  'Amortization of Goodwill and Intangible Assets':
-    'Amortización de fondos de comercio y activos intangibles',
-  'Other Operating Expenses': 'Otros gastos operacionales',
-  'Total Operating Expenses': 'Gastos operativos totales',
-  'Operating Income': 'Beneficio operativo',
-  '% Operating Margins': '% Márgenes operativos',
-  'Interest Expense': 'Gastos por intereses',
-  'Interest And Investment Income': 'Ingresos por intereses e inversiones',
-  'Currency Exchange Gains (Loss)': 'Ganancias (pérdidas) cambiarias',
-  'Other Non Operating Income (Expenses)':
-    'Otros ingresos (gastos) no operativos',
-  'EBT Excl. Unusual Items': 'EBT excl. Artículos inusuales',
-  'Merger & Restructuring Charges': 'Cargos de fusión y reestructuración',
-  'Impairment of Goodwill': 'Deterioro del fondo de comercio',
-  'Gain (Loss) On Sale Of Investments':
-    'Ganancia (pérdida) por venta de inversiones',
-  'Legal Settlements': 'Acuerdos legales',
-  'Other Unusual Items': 'Otros artículos inusuales',
-  'EBT Incl. Unusual Items': 'EBT incl. Artículos extraordinarios',
-  'Income Tax Expense': 'Gastos de impuestos',
-  'Earnings From Continuing Operations':
-    'Beneficios por operaciones continuadas',
-  'Net Income to Company': 'Beneficio neto de la empresa',
-  'Net Income': 'Beneficio neto',
-  'Preferred Dividend and Other Adjustments':
-    'Dividendo preferente y otros ajustes',
-  'Net Income to Common Incl Extra Items':
-    'Beneficio neto a acciones comunes incluidos extraordinarios',
-  '% Net Income to Common Incl Extra Items Margins':
-    'Margen de beneficio neto a acciones comunes incluidos extraordinarios %',
-  'Net Income to Common Excl. Extra Items':
-    'Beneficio neto a acciones comunes excluidos extraordinarios',
-  '% Net Income to Common Excl. Extra Items Margins':
-    'Margen de beneficio neto a acciones comunes excluidos extraordinarios %',
-  'Supplementary Data:': 'Datos adicionales:',
-  'Diluted EPS Excl Extra Items': 'BPA diluido sin extraordinarios',
-  'Weighted Average Diluted Shares Outstanding':
-    'Promedio ponderado de acciones diluidas en circulación',
-  'Weighted Average Basic Shares Outstanding':
-    'Promedio ponderado de acciones básicas en circulación',
-  'Basic EPS': 'BPA básico',
-  EBITDA: 'EBITDA',
-  EBITDAR: 'EBITDAR',
-  'Selling and Marketing Expense': 'Gastos de venta y marketing',
-  'Effective Tax Rate %': 'Tasa efectiva de impuestos %',
-  'Market Cap': 'Capitalización de mercado',
-  'Price Close': 'Precio de cierre',
-  TEV: 'TEV',
-  'Cash And Equivalents': 'Efectivo y equivalentes',
-  'Total Cash And Short Term Investments':
-    'Efectivo total e inversiones a corto plazo',
-  'Accounts Receivable': 'Cuentas por cobrar',
-  'Other Receivables': 'Otros por cobrar',
-  'Notes Receivable': 'Notas por cobrar',
-  'Total Receivables': 'Total de cuentas por cobrar',
-  'Prepaid Expenses': 'Gastos pagados por anticipado',
-  'Restricted Cash': 'Efectivo restringido',
-  'Other Current Assets': 'Otro activo corriente',
-  'Total Current Assets': 'Total de activo corriente',
-  'Gross Property Plant And Equipment': 'Inmovilizado material bruto',
-  'Accumulated Depreciation': 'Depreciación acumulada',
-  'Net Property Plant And Equipment': 'Inmovilizado material neto',
-  Goodwill: 'Fondo de comercio',
-  'Other Intangibles': 'Otros intangibles',
-  'Deferred Tax Assets Long-Term':
-    'Activos por impuestos diferidos a largo plazo',
-  'Deferred Charges Long-Term': 'Cargos diferidos a largo plazo',
-  'Other Long-Term Assets': 'Otros activos a largo plazo',
-  'Total Assets': 'Activo total',
-  'Accounts Payable': 'Cuentas por pagar',
-  'Accrued Expenses': 'Gastos devengados',
-  'Short-term Borrowings': 'Préstamos de corto plazo',
-  'Current Portion of Long-Term Debt':
-    'Porción corriente de la deuda a largo plazo',
-  'Current Portion of Capital Lease Obligations':
-    'Porción corriente de las obligaciones de arrendamiento financiero',
-  'Unearned Revenue Current': 'Ingresos no devengados (corriente)',
-  'Other Current Liabilities': 'Otros pasivos corrientes',
-  'Total Current Liabilities': 'Total pasivo corriente',
-  'Long-Term Debt': 'Deuda a largo plazo',
-  'Capital Leases': 'Arrendamientos de capitales',
-  'Deferred Tax Liability Non Current':
-    'Pasivo por impuesto diferido no corriente',
-  'Other Non Current Liabilities': 'Otro pasivo no corrientes',
-  'Total Liabilities': 'Pasivo Total',
-  'Common Stock': 'Acciones comunes',
-  'Additional Paid In Capital': 'Prima de suscripción',
-  'Retained Earnings': 'Beneficio no distribuido',
-  'Treasury Stock': 'Autocartera',
-  'Comprehensive Income and Other': 'Resultado integral y otros',
-  'Total Common Equity': 'Patrimonio neto común total',
-  'Total Equity': 'Fondos propios totales',
-  'Total Liabilities And Equity': 'Pasivo total y patrimonio neto',
-  'Total Shares Out. on Filing Date':
-    'Total de acciones fuera. en la fecha de presentación',
-  'Book Value / Share': 'Valor contable / Acción',
-  'Tangible Book Value': 'Valor contable tangible',
-  'Tangible Book Value / Share': 'Valor contable tangible / acción',
-  'Total Debt': 'Deuda total',
-  'Net Debt': 'Deuda neta',
-  Land: 'Terrenos',
-  Buildings: 'Edificios',
-  'Construction In Progress': 'Construcción en progreso',
-  'Full Time Employees': 'Empleados a tiempo completo',
-  'Cash Flow Statement': 'Estado de flujo de efectivo',
-  'Total Depreciation & Amortization': 'Depreciación y amortización total',
-  'Amortization of Deferred Charges': 'Amortización de cargos diferidos',
-  '(Gain) Loss on Sale of Investments':
-    '(Ganancia) Pérdida por venta de inversiones',
-  'Asset Writedown & Restructuring Costs':
-    'Deterioro de activos y costes de reestructuración',
-  'Stock-Based Compensation': 'Compensación de stock options',
-  'Other Operating Activities': 'Otras actividades operativas',
-  'Change In Accounts Receivable': 'Cambio en cuentas por cobrar',
-  'Change In Accounts Payable': 'Cambio en cuentas por pagar',
-  'Change in Unearned Revenues': 'Cambio en los ingresos no devengados',
-  'Change in Other Net Operating Assets':
-    'Variación en otros activos operativos netos',
-  'Cash from Operations': 'Efectivo de Operaciones',
-  'Memo: Change in Net Working Capital':
-    'Nota: Cambio en el capital circulante',
-  'Capital Expenditure': 'Gastos de capital',
-  'Cash Acquisitions': 'Adquisiciones con efectivo',
-  'Sale (Purchase) of Intangible assets':
-    'Venta (compra) de activos intangibles',
-  'Other Investing Activities': 'Otras actividades de inversión',
-  'Cash from Investing': 'Efectivo de la inversión',
-  'Total Debt Issued': 'Deuda total emitida',
-  'Total Debt Repaid': 'Total de la deuda reembolsada',
-  'Issuance of Common Stock': 'Emisión de acciones ordinarias',
-  'Repurchase of Common Stock': 'Recompra de acciones comunes',
-  'Other Financing Activities': 'Otras Actividades de Financiamiento',
-  'Cash from Financing': 'Efectivo de Financiamiento',
-  'Foreign Exchange Rate Adjustments': 'Ajustes del tipo de cambio de divisas',
-  'Net Change in Cash': 'Cambio neto en efectivo',
-  'Free Cash Flow': 'Flujo de caja libre',
-  '% Free Cash Flow Margins': '% Márgenes de flujo de caja libre',
-  'Cash and Cash Equivalents, Beginning of Period':
-    'Efectivo y equivalentes de efectivo, comienzo del período',
-  'Cash and Cash Equivalents, End of Period':
-    'Efectivo y equivalentes de efectivo, fin de período',
-  'Cash Interest Paid': 'Intereses en efectivo pagados',
-  'Cash Taxes Paid': 'Impuestos en efectivo pagados',
-  'Cash Flow per Share': 'Flujo de caja por acción'
-};
-
-const FINANCIAL_SYNONYMS = {
-  sga: 'Selling General & Admin Expenses',
-  'sg&a': 'Selling General & Admin Expenses',
-  'selling general & admin': 'Selling General & Admin Expenses',
-  'selling general and admin': 'Selling General & Admin Expenses',
-  'selling, general & administrative': 'Selling General & Admin Expenses',
-  'selling general & administrative': 'Selling General & Admin Expenses',
-  'cash and cash equivalents': 'Cash And Equivalents',
-  'capital expenditures': 'Capital Expenditure',
-  'capital expenditure': 'Capital Expenditure',
-  'unearned revenue current': 'Unearned Revenue Current'
-};
-
-const LABEL_NORMALIZATION_FIXES = {
-  inmobilizado: 'inmovilizado',
-  'beneficio netos': 'beneficio neto',
-  extradordinarios: 'extraordinarios'
-};
-
-const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-const LABEL_FIX_PATTERNS = Object.entries(LABEL_NORMALIZATION_FIXES).map(
-  ([wrong, ok]) => [new RegExp(escapeRegExp(wrong), 'gi'), ok]
-);
-
-function normalizeLabelText(label) {
-  if (!label) return '';
-  let out = String(label)
-    .replace(/\u00A0/g, ' ')
-    .replace(/\s+/g, ' ')
-    .replace(/\s*%\s*/g, ' % ')
-    .trim();
-  LABEL_FIX_PATTERNS.forEach(([re, ok]) => {
-    out = out.replace(re, ok);
-  });
-  return out.replace(/%\s+\)/g, '%)').replace(/\s+/g, ' ').trim();
-}
-
-function normalizeSentenceText(text) {
-  return String(text ?? '')
-    .replace(/\u00A0/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-const FINANCIAL_LABEL_NORMALIZED_EN = Object.fromEntries(
-  Object.entries(FINANCIAL_LABEL_EN_ES).map(([en, es]) => [
-    normalizeLabelText(en).toLowerCase(),
-    { en, es }
-  ])
-);
-
-const FINANCIAL_LABEL_NORMALIZED_ES = Object.fromEntries(
-  Object.entries(FINANCIAL_LABEL_EN_ES).map(([en, es]) => [
-    normalizeLabelText(es).toLowerCase(),
-    { en, es }
-  ])
-);
-
-function canonicalizeFinancialLabel(label) {
-  const raw = String(label || '');
-  const normalized = normalizeLabelText(raw);
-  const key = normalized.toLowerCase();
-  const exactEn = FINANCIAL_LABEL_NORMALIZED_EN[key];
-  if (exactEn)
-    return {
-      raw,
-      normalized,
-      canonicalEn: exactEn.en,
-      es: exactEn.es,
-      match: 'exact_en'
-    };
-
-  const exactEs = FINANCIAL_LABEL_NORMALIZED_ES[key];
-  if (exactEs)
-    return {
-      raw,
-      normalized,
-      canonicalEn: exactEs.en,
-      es: exactEs.es,
-      match: 'exact_es'
-    };
-
-  const syn = FINANCIAL_SYNONYMS[normalized.toLowerCase()];
-  if (syn && FINANCIAL_LABEL_EN_ES[syn]) {
-    return {
-      raw,
-      normalized,
-      canonicalEn: syn,
-      es: FINANCIAL_LABEL_EN_ES[syn],
-      match: 'synonym'
-    };
-  }
-
-  return { raw, normalized, canonicalEn: raw, es: raw, match: 'fallback' };
-}
-
-function translateFinancialLabel(label) {
-  const c = canonicalizeFinancialLabel(label);
-  return currentLang === 'es' ? c.es || c.raw : c.canonicalEn || c.raw;
-}
-
-const DYNAMIC_I18N = {
-  sectionTitles: {
-    Growth: 'Crecimiento',
-    'Profitability & Margins': 'Rentabilidad y Márgenes',
-    'Cost Structure & OpEx': 'Estructura de Costes y OpEx',
-    'Returns & Economic Moat': 'Retornos y Foso Económico',
-    'Balance Sheet Composition': 'Composición del Balance',
-    'Debt & Financial Health': 'Deuda y Salud Financiera',
-    'Cash Flow Quality': 'Calidad del Flujo de Caja',
-    'Efficiency & Operations': 'Eficiencia y Operaciones',
-    Valuation: 'Valoración',
-    'Dividends & Shareholder Returns': 'Dividendos y Retorno al Accionista',
-    'Consensus Estimates': 'Estimaciones de Consenso',
-    'Analyst Sentiment (Low weight / noisy — ruido)':
-      'Sentimiento de Analistas (bajo peso / ruidoso)',
-    'Harmony & Red Flags': 'Armonía y Banderas Rojas',
-    'Balance Sheet Reality Check': 'Chequeo de Realidad del Balance',
-    'Cash Flow — The Truth Serum': 'Flujo de Caja — Suero de la Verdad'
-  },
-  metricNames: {
-    'Current Ratio': 'Ratio Corriente',
-    'Quick Ratio': 'Ratio Rápido',
-    'Revenue Growth (CAGR)': 'Crecimiento de Ingresos (CAGR)',
-    'Revenue YoY Growth': 'Crecimiento interanual de ingresos',
-    'EPS Growth (Diluted)': 'Crecimiento del BPA (diluido)',
-    'EBITDA Growth': 'Crecimiento del EBITDA',
-    'Operating Income Growth': 'Crecimiento del beneficio operativo',
-    'Net Income Growth': 'Crecimiento del beneficio neto',
-    'Free Cash Flow Growth': 'Crecimiento del flujo de caja libre',
-    'Gross Margin': 'Margen bruto',
-    'Operating Margin (EBIT)': 'Margen operativo (EBIT)',
-    'EBITDA Margin': 'Margen EBITDA',
-    'FCF Margin': 'Margen de FCF',
-    'Margin Expansion vs Gross': 'Expansión de márgenes vs bruto',
-    'Operating Leverage': 'Apalancamiento operativo',
-    'COGS as % of Revenue': 'COGS como % de ingresos',
-    'Operating Expenses as % of Gross Profit':
-      'Gastos operativos como % del beneficio bruto',
-    'SG&A as % of Revenue': 'SG&A como % de ingresos',
-    'R&D as % of Revenue': 'I+D como % de ingresos',
-    'Effective Tax Rate': 'Tasa efectiva de impuestos',
-    'Interest Expense as % of Revenue':
-      'Gastos por intereses como % de ingresos',
-    'Stock-Based Comp as % of Revenue':
-      'Compensación en acciones como % de ingresos',
-    'ROIC (Return on Invested Capital)':
-      'ROIC (Retorno sobre Capital Invertido)',
-    'ROE (Return on Equity)': 'ROE (Retorno sobre Patrimonio)',
-    'ROA (Return on Assets)': 'ROA (Retorno sobre Activos)',
-    'Equity Multiplier (ROE/ROA)': 'Multiplicador de patrimonio (ROE/ROA)',
-    'Asset Turnover': 'Rotación de activos',
-    'Receivables Turnover': 'Rotación de cuentas por cobrar',
-    'Inventory Turnover': 'Rotación de inventarios',
-    'Cash Conversion Cycle': 'Ciclo de conversión de caja',
-    'Days Sales Outstanding (DSO)': 'Días de ventas pendientes (DSO)',
-    'Enterprise Value vs Market Cap':
-      'Enterprise Value vs Capitalización de mercado',
-    'Forward P/E (NTM)': 'P/E futuro (NTM)',
-    'Price / Sales': 'Precio / Ventas',
-    'Price / Book Value': 'Precio / Valor contable',
-    'EV/EBITDA (NTM)': 'EV/EBITDA (NTM)',
-    'EV/EBIT': 'EV/EBIT',
-    'FCF Yield (NTM)': 'Rentabilidad FCF (NTM)',
-    'Dividend Yield': 'Rentabilidad por dividendo',
-    'P/E Context Map (informational)': 'Mapa de contexto P/E (informativo)',
-    'Dividends Per Share': 'Dividendos por acción',
-    'Payout Ratio': 'Payout ratio',
-    'Total Dividends Paid': 'Dividendos totales pagados',
-    'Share Buybacks': 'Recompras de acciones',
-    'Share Issuance (Dilution)': 'Emisión de acciones (dilución)',
-    'Diluted Shares Outstanding': 'Acciones diluidas en circulación',
-    'Total Shareholder Yield': 'Retorno total al accionista',
-    'Consensus Revenue Estimate': 'Estimación de ingresos de consenso',
-    'Consensus EPS Estimate': 'Estimación de BPA de consenso',
-    'Consensus EBITDA Estimate': 'Estimación de EBITDA de consenso',
-    'Consensus FCF Estimate': 'Estimación de FCF de consenso',
-    'Revenue vs Earnings Harmony': 'Armonía ingresos vs beneficios',
-    'CFO vs Net Income (Accrual Risk, LTM)':
-      'CFO vs Beneficio neto (riesgo de devengo)',
-    'FCF Consistency Check': 'Chequeo de consistencia del FCF',
-    'Net Debt / Net Cash': 'Deuda neta / Caja neta',
-    'Cash / Short-Term Debt': 'Caja / Deuda a corto plazo',
-    'Receivables Days Trend': 'Tendencia de días de cobro',
-    'Inventory vs Revenue Growth': 'Crecimiento inventario vs ingresos',
-    'Goodwill + Intangibles Concentration':
-      'Concentración de fondo de comercio + intangibles',
-    'Deferred Revenue Signal': 'Señal de ingresos diferidos',
-    'FCF Uses Summary': 'Resumen de usos del FCF',
-    'SBC as % of FCF': 'SBC como % del FCF',
-    'SBC as % of Net Income': 'SBC como % del beneficio neto'
-  },
-  fragments: {
-    Latest: 'Último',
-    Avg: 'Promedio',
-    Trend: 'Tendencia',
-    'Insufficient data': 'Datos insuficientes',
-    Strong: 'Fuerte',
-    Moderate: 'Moderado',
-    Slow: 'Lento',
-    Declining: 'En descenso',
-    'Very Liquid': 'Muy líquido',
-    Healthy: 'Saludable',
-    OK: 'Correcto',
-    'Low Liquidity ⚠️': 'Liquidez baja ⚠️',
-    'Excludes inventory — more conservative than current ratio':
-      'Excluye inventario: más conservador que el ratio corriente',
-    'Very Healthy': 'Muy saludable',
-    Adequate: 'Adecuado',
-    'Tight Liquidity ⚠️': 'Liquidez ajustada ⚠️',
-    'Not enough data': 'Datos insuficientes',
-    'see details': 'ver detalle',
-    Quality: 'Calidad',
-    Moat: 'Foso',
-    'Financial Risk': 'Riesgo Financiero',
-    'Overall Health': 'Salud General',
-    Valuation: 'Valoración',
-    Growth: 'Crecimiento',
-    Margins: 'Márgenes',
-    Costs: 'Costes',
-    Balance: 'Balance',
-    Debt: 'Deuda',
-    Cashflow: 'Flujo de caja',
-    Efficiency: 'Eficiencia',
-    Shareholder: 'Accionista',
-    Harmony: 'Armonía',
-    Good: 'Bueno',
-    Excellent: 'Excelente',
-    Average: 'Medio',
-    Poor: 'Débil',
-    Volatile: 'Volátil',
-    Decent: 'Decente',
-    'Best-in-class': 'Líder de clase',
-    Elite: 'Élite',
-    'Cash Machine': 'Máquina de caja',
-    'Some Leverage': 'Algo de apalancamiento',
-    'Investing in Innovation': 'Invirtiendo en innovación',
-    Outstanding: 'Sobresaliente',
-    'Negative CCC (Uses supplier float!)':
-      'CCC negativo (usa financiación de proveedores)',
-    'Strong supplier float (supplier financing)':
-      'Fuerte supplier float (financiación de proveedores)',
-    'Low payables float': 'Float de proveedores bajo',
-    'Context only': 'Solo contexto',
-    'Never Cut — Reliable': 'Nunca recortado — fiable',
-    'In line': 'En línea',
-    Manageable: 'Manejable',
-    Contained: 'Contenido',
-    Acceptable: 'Aceptable',
-    'Aligned Growth': 'Crecimiento alineado',
-    'Cash-backed earnings': 'Beneficios respaldados por caja',
-    Neutral: 'Neutral',
-    Covered: 'Cubierto',
-    Stable: 'Estable',
-    Limited: 'Limitado',
-    Fair: 'Razonable',
-    Expensive: 'Caro',
-    'Very Rich': 'Muy exigente',
-    Rich: 'Exigente',
-    'Token Dividend': 'Dividendo simbólico',
-    'Very Safe': 'Muy seguro',
-    'Growing Distributions': 'Distribuciones crecientes',
-    'Active Buybacks': 'Recompras activas',
-    'Heavy Dilution ⚠️': 'Fuerte dilución ⚠️',
-    'Shrinking ✓': 'Reduciéndose ✓',
-    'Excellent Capital Return': 'Excelente retorno de capital',
-    annual: 'anual',
-    '2-minute Quality': 'Calidad en 2 minutos',
-    '2-minute Moat': 'Foso en 2 minutos',
-    '2-minute Financial Risk': 'Riesgo financiero en 2 minutos',
-    '2-minute Valuation': 'Valoración en 2 minutos',
-    'Return on Equity': 'Retorno sobre el patrimonio',
-    'Return on Assets': 'Retorno sobre activos',
-    'Enterprise Value vs Capitalización de mercado':
-      'Valor de empresa (EV) vs capitalización de mercado',
-    'Enterprise Value vs Market Cap':
-      'Valor de empresa (EV) vs capitalización de mercado',
-    'Revenue vs Earnings Harmony': 'Armonía entre ingresos y beneficios',
-    Revenue: 'ingresos',
-    Earnings: 'beneficios',
-    'Revenue YoY': 'Ingresos interanuales (YoY)',
-    'Earnings YoY': 'Beneficios interanuales (YoY)',
-    'Std dev': 'desviación estándar',
-    'erratic growth': 'crecimiento errático',
-    'Net Profit Margin': 'Margen de beneficio neto',
-    Exceptional: 'Excepcional',
-    Stability: 'Estabilidad',
-    stable: 'estable',
-    up: 'al alza',
-    'Gross Δ': 'Δ (cambio) bruto',
-    'Op Δ': 'Δ (cambio) operativo',
-    'Watch for cost structure issues':
-      'Vigila posibles problemas en la estructura de costes',
-    'Operating Expenses as % of Beneficio bruto':
-      'Gastos operativos como % del beneficio bruto',
-    'Golden rule: OpEx should not eat most gross profit (gastos operativos controlados).':
-      'Regla de oro: el OpEx no debería comerse la mayor parte del beneficio bruto (gastos operativos controlados).',
-    Controlled: 'Controlado',
-    'SG&A': 'Gastos de venta, generales y administrativos (SG&A)',
-    'Lower is better — shows operational efficiency':
-      'Cuanto más bajo, mejor — indica eficiencia operativa',
-    Minimal: 'Mínimo',
-    'Beware: high leverage can inflate ROE artificially':
-      'Ojo: un apalancamiento alto puede inflar el ROE artificialmente',
-    'Equity Multiplier': 'Multiplicador del patrimonio (apalancamiento)',
-    'Leverage-driven ROE': 'ROE impulsado por apalancamiento',
-    Leveraged: 'Apalancada / con alto apalancamiento',
-    'Private equity stress threshold is typically 4-5x':
-      'El umbral de estrés típico en private equity suele ser 4–5x',
-    'Very Low Debt': 'Deuda muy baja',
-    'Very Low Deuda': 'Deuda muy baja',
-    'Very Efficient': 'Muy eficiente',
-    'Excellent Collection': 'Excelente gestión de cobros',
-    'Negative CCC = the business generates cash before paying suppliers (very powerful)':
-      'CCC negativo = el negocio genera efectivo antes de pagar a proveedores (muy potente)',
-    'Buybacks reduce share count and boost EPS':
-      'Las recompras reducen el número de acciones y elevan el BPA (EPS)',
-    'Fewer shares = more value per share for existing holders':
-      'Menos acciones = más valor por acción para los accionistas actuales',
-    'Buybacks + dividends as % of market cap':
-      'Recompras + dividendos como % de la capitalización bursátil',
-    'Aligned Crecimiento': 'Crecimiento alineado',
-    Aligned: 'Alineado',
-    'Healthy conversion': 'Conversión saludable',
-    Disciplined: 'Disciplinado',
-    'Capital allocation context': 'Contexto de asignación de capital',
-    'Classic heuristic: net margin >10% good, >20% excellent (sector-aware).':
-      'Heurística clásica: margen neto >10% es bueno, >20% es excelente (dependiendo del sector).',
-    'Classic heuristic: net margin >10 % good, >20 % excellent (sector-aware).':
-      'Heurística clásica: margen neto >10% es bueno, >20% es excelente (dependiendo del sector).',
-    'Gross vs Net Margin': 'Margen bruto vs margen neto',
-    'Operating Discipline': 'Disciplina operativa',
-    'If gross margin is stable but operating margin falls, overhead is eating profitability.':
-      'Si el margen bruto se mantiene estable pero cae el margen operativo, los costes fijos/estructura se están comiendo la rentabilidad.',
-    FCF: 'flujo de caja libre (FCF)',
-    'Revenue trend: up | Earnings trend: stable | FCF trend: stable':
-      'Tendencia de ingresos: al alza | tendencia de beneficios: estable | tendencia de FCF: estable',
-    'FCF is the crown jewel: rising profits should eventually show up in free cash flow.':
-      'El FCF es la joya de la corona: si los beneficios suben, debería terminar viéndose en el flujo de caja libre.',
-    'Deuda neta / Net Cash': 'Deuda neta / caja neta',
-    'Net Cash': 'caja neta',
-    'Frequent large acquisitions increase integration risk':
-      'Adquisiciones grandes y frecuentes aumentan el riesgo de integración',
-    'Acquisition-heavy': 'Intensiva en adquisiciones',
-    'debt paydown': 'amortización de deuda',
-    'cash build': 'aumento/acumulación de caja',
-    'FCF used for': 'FCF destinado a',
-    '% of FCF': '% del FCF',
-    buybacks: 'recompras',
-    dividends: 'dividendos',
-    EPS: 'BPA (beneficio por acción)',
-    'NI/EPS': 'beneficio neto / BPA'
-  }
-};
-
-const FIN_LABEL_ENTRIES = Object.entries(FINANCIAL_LABEL_EN_ES).sort(
-  (a, b) => b[0].length - a[0].length
-);
-const reverseAndSortByFromLen = (entries) =>
-  entries
-    .map(([from, to]) => [to, from])
-    .sort((a, b) => b[0].length - a[0].length);
-
-const FIN_LABEL_ENTRIES_REVERSED = reverseAndSortByFromLen(FIN_LABEL_ENTRIES);
-const METRIC_ENTRIES = Object.entries(DYNAMIC_I18N.metricNames).sort(
-  (a, b) => b[0].length - a[0].length
-);
-const METRIC_ENTRIES_REVERSED = reverseAndSortByFromLen(METRIC_ENTRIES);
-const SECTION_ENTRIES = Object.entries(DYNAMIC_I18N.sectionTitles).sort(
-  (a, b) => b[0].length - a[0].length
-);
-const SECTION_ENTRIES_REVERSED = reverseAndSortByFromLen(SECTION_ENTRIES);
-const FRAG_ENTRIES = Object.entries(DYNAMIC_I18N.fragments).sort(
-  (a, b) => b[0].length - a[0].length
-);
-const FRAG_ENTRIES_REVERSED = reverseAndSortByFromLen(FRAG_ENTRIES);
-
-function compileReplacers(entries) {
-  return entries.map(([from, to]) => {
-    const hasAlphaNum = /[A-Za-z0-9]/.test(from);
-    if (!hasAlphaNum) {
-      return {
-        replace: (text) => text.replaceAll(from, to)
-      };
-    }
-    const escaped = escapeRegExp(from);
-    const re = new RegExp(
-      `(^|[^\\p{L}\\p{N}_])(${escaped})(?=$|[^\\p{L}\\p{N}_])`,
-      'gu'
-    );
-    return {
-      replace: (text) => text.replace(re, (_, lead) => `${lead}${to}`)
-    };
-  });
-}
-
-const METRIC_REPLACERS_ES = compileReplacers(METRIC_ENTRIES);
-const METRIC_REPLACERS_EN = compileReplacers(METRIC_ENTRIES_REVERSED);
-const SECTION_REPLACERS_ES = compileReplacers(SECTION_ENTRIES);
-const SECTION_REPLACERS_EN = compileReplacers(SECTION_ENTRIES_REVERSED);
-const FRAG_REPLACERS_ES = compileReplacers(FRAG_ENTRIES);
-const FRAG_REPLACERS_EN = compileReplacers(FRAG_ENTRIES_REVERSED);
-const FIN_REPLACERS_ES = compileReplacers(FIN_LABEL_ENTRIES);
-const FIN_REPLACERS_EN = compileReplacers(FIN_LABEL_ENTRIES_REVERSED);
-
-function localizeDynamicText(text) {
-  if (!text) return text;
-  let out = normalizeSentenceText(text);
-
-  const metricReplacers =
-    currentLang === 'es' ? METRIC_REPLACERS_ES : METRIC_REPLACERS_EN;
-  metricReplacers.forEach((replacer) => {
-    out = replacer.replace(out);
-  });
-
-  const sectionReplacers =
-    currentLang === 'es' ? SECTION_REPLACERS_ES : SECTION_REPLACERS_EN;
-  sectionReplacers.forEach((replacer) => {
-    out = replacer.replace(out);
-  });
-
-  const fragmentReplacers =
-    currentLang === 'es' ? FRAG_REPLACERS_ES : FRAG_REPLACERS_EN;
-  fragmentReplacers.forEach((replacer) => {
-    out = replacer.replace(out);
-  });
-
-  const financialReplacers =
-    currentLang === 'es' ? FIN_REPLACERS_ES : FIN_REPLACERS_EN;
-  financialReplacers.forEach((replacer) => {
-    out = replacer.replace(out);
-  });
-
-  return out;
-}
-
-function parseMetricDetail(detail) {
-  if (!detail) return null;
-  const normalized = String(detail).replace(/\s+/g, ' ').trim();
-  if (!normalized) return null;
-
-  const segments = normalized
-    .split(/\s*•\s*|\s+\|\s+/)
-    .map((segment) => segment.trim())
-    .filter(Boolean);
-
-  if (!segments.length) return null;
-
-  const interpretationRe = /^(interpretaci[oó]n|interpretation)\s*:\s*/i;
-  let summaryMain = segments.shift() || '';
-  let summaryInterpretation = '';
-
-  const summaryInterpretationMatch = summaryMain.match(
-    /(.*?)(?:\s*[—-]\s*)?(interpretaci[oó]n|interpretation)\s*:\s*(.+)$/i
-  );
-  if (summaryInterpretationMatch) {
-    summaryMain = summaryInterpretationMatch[1]?.trim() || summaryMain;
-    summaryInterpretation = summaryInterpretationMatch[3]?.trim() || '';
-  }
-
-  const items = [];
-  segments.forEach((segment) => {
-    if (interpretationRe.test(segment) && !summaryInterpretation) {
-      summaryInterpretation = segment.replace(interpretationRe, '').trim();
-      return;
-    }
-    items.push(segment);
-  });
-
-  if (!summaryMain && items.length) {
-    summaryMain = items.shift() || '';
-  }
-
-  return {
-    summaryMain,
-    summaryInterpretation,
-    items
-  };
-}
-
-function renderMetricDetail(detail) {
-  const parsed = parseMetricDetail(detail);
-  if (!parsed) return '';
-
-  const hasStructuredDetail = parsed.items.length > 0 || parsed.summaryInterpretation;
-  if (!hasStructuredDetail) {
-    return `<div class="metric-detail">${localizeDynamicText(parsed.summaryMain)}</div>`;
-  }
-
-  const summaryMain = localizeDynamicText(parsed.summaryMain);
-  const summaryInterpretation = parsed.summaryInterpretation
-    ? `<span class="md-interpret">${localizeDynamicText(parsed.summaryInterpretation)}</span>`
-    : '';
-  const listItems = parsed.items
-    .map((item) => {
-      const idx = item.indexOf(':');
-      if (idx <= 0) return `<li>${localizeDynamicText(item)}</li>`;
-      const label = item.slice(0, idx).trim();
-      const value = item.slice(idx + 1).trim();
-      if (!value) return `<li>${localizeDynamicText(item)}</li>`;
-      return `<li><span class="md-label">${localizeDynamicText(label + ':')}</span> ${localizeDynamicText(value)}</li>`;
-    })
-    .join('');
-
-  return `<details class="metric-detail"><summary><span class="md-kpi">${summaryMain}</span>${summaryInterpretation}</summary><ul class="md-list">${listItems}</ul></details>`;
-}
-
-function splitDetailLabelValue(detailItem) {
-  const idx = String(detailItem || '').indexOf(':');
-  if (idx <= 0) return null;
-  const label = detailItem.slice(0, idx).trim();
-  const value = detailItem.slice(idx + 1).trim();
-  if (!label || !value) return null;
-  return { label, value };
-}
-
-function renderPrintableMetricDetail(item) {
-  const parsed = parseMetricDetail(item.detail || '');
-  const headline = localizeDynamicText(
-    parsed?.summaryMain || item.value || item.detail || ''
-  );
-  const bullets = [];
-
-  if (parsed?.summaryInterpretation) {
-    bullets.push({
-      label: currentLang === 'es' ? 'Interpretación:' : 'Interpretation:',
-      value: localizeDynamicText(parsed.summaryInterpretation)
-    });
-  }
-
-  (parsed?.items || []).forEach((entry) => {
-    const split = splitDetailLabelValue(entry);
-    if (split) {
-      bullets.push({
-        label: localizeDynamicText(split.label + ':'),
-        value: localizeDynamicText(split.value)
-      });
-      return;
-    }
-    bullets.push({ value: localizeDynamicText(entry) });
-  });
-
-  if (!parsed && item.detail) {
-    bullets.push({ value: localizeDynamicText(item.detail) });
-  }
-
-  if (item.explanation) {
-    bullets.push({
-      label: currentLang === 'es' ? 'Datos:' : 'Data:',
-      value: localizeDynamicText(item.explanation)
-    });
-  }
-
-  if (!bullets.length) {
-    bullets.push({
-      value: currentLang === 'es' ? 'Sin detalle adicional.' : 'No additional detail.'
-    });
-  }
-
-  const bulletHtml = bullets
-    .map((bullet) => {
-      if (!bullet.label) return `<li>${escapeHtml(bullet.value)}</li>`;
-      return `<li><strong>${escapeHtml(bullet.label)}</strong> ${escapeHtml(bullet.value)}</li>`;
-    })
-    .join('');
-
-  return {
-    headline,
-    bulletHtml
-  };
 }
 
 // =========================================================
@@ -6592,11 +5871,11 @@ function escapeHtml(value) {
 function buildPrintableDashboardPanel(data, results, industrySelection = null) {
   const sectionBlocks = (results.sections || [])
     .map((section) => {
-      const sectionTitle = `${section.icon || '•'} ${localizeDynamicText(section.title || '')}`;
+      const sectionTitle = `${section.icon || '•'} ${localizeDynamicText(section.title || '', currentLang)}`;
       const metrics = (section.items || [])
         .map((item) => {
-          const metricName = localizeDynamicText(item.name || 'Metric');
-          const signalText = localizeDynamicText(item.signalText || '');
+          const metricName = localizeDynamicText(item.name || 'Metric', currentLang);
+          const signalText = localizeDynamicText(item.signalText || '', currentLang);
           const signal =
             item.signal === 'bull'
               ? currentLang === 'es'
@@ -6609,8 +5888,8 @@ function buildPrintableDashboardPanel(data, results, industrySelection = null) {
                 : currentLang === 'es'
                   ? '🟡 Neutral'
                   : '🟡 Neutral';
-          const note = localizeDynamicText(item.note || '');
-          const { headline, bulletHtml } = renderPrintableMetricDetail(item);
+          const note = localizeDynamicText(item.note || '', currentLang);
+          const { headline, bulletHtml } = renderPrintableMetricDetail(item, currentLang, escapeHtml);
           return `<li class="print-metric">
             <div class="print-title">${escapeHtml(metricName)}</div>
             ${headline ? `<div class="print-headline">${escapeHtml(headline)}</div>` : ''}
@@ -6678,7 +5957,7 @@ export function renderDashboard(data, results, industrySelection = null) {
     <div class="dash-header fade-up">
       <div>
         <h2>${data.ticker ? data.ticker + ' — ' : ''}${data.company}</h2>
-        <span class="price">${data.price || ''} ${data.period ? '• ' + localizeDynamicText(data.period) : ''} • ${results.totalMetrics} ${t('metricsAnalyzed', 'metrics analyzed')}</span>
+        <span class="price">${data.price || ''} ${data.period ? '• ' + localizeDynamicText(data.period, currentLang) : ''} • ${results.totalMetrics} ${t('metricsAnalyzed', 'metrics analyzed')}</span>
       </div>
       <div class="header-actions">
         <button class="btn-toggle-sections" onclick="switchDashboardTab('print')">${currentLang === 'es' ? '🖨️ Imprimir' : '🖨️ Print'}</button>
@@ -6720,21 +5999,21 @@ export function renderDashboard(data, results, industrySelection = null) {
     const bears = signals.filter((i) => i.signal === 'bear').length;
     const bulls = signals.filter((i) => i.signal === 'bull').length;
     const grade = bears >= 2 ? 'poor' : bulls > bears ? 'good' : 'average';
-    const driver = localizeDynamicText(signals[0]?.name || 'Not enough data');
+    const driver = localizeDynamicText(signals[0]?.name || 'Not enough data', currentLang);
     const light = grade === 'poor' ? '🔴' : grade === 'good' ? '🟢' : '🟡';
-    html += `<div class="score-card ${grade} fade-up"><div class="label">${localizeDynamicText(`2-minute ${cat.k}`)}</div><div class="value">${light} ${gradeLabel(grade)}</div><div class="detail">${driver} · <a href="${cat.href}" style="color:var(--accent)">${localizeDynamicText('see details')}</a></div></div>`;
+    html += `<div class="score-card ${grade} fade-up"><div class="label">${localizeDynamicText(`2-minute ${cat.k}`, currentLang)}</div><div class="value">${light} ${gradeLabel(grade)}</div><div class="detail">${driver} · <a href="${cat.href}" style="color:var(--accent)">${localizeDynamicText('see details', currentLang)}</a></div></div>`;
   });
   html += `</div>`;
 
   const cards = [
     {
-      label: localizeDynamicText('Overall Health'),
+      label: localizeDynamicText('Overall Health', currentLang),
       value: overallLabel,
       grade: results.overall,
       detail: `${currentLang === 'es' ? 'Puntuación' : 'Score'}: ${results.overallScore?.toFixed(1)}/4.0`
     },
     ...Object.entries(results.scores).map(([k, g]) => ({
-      label: localizeDynamicText(k.charAt(0).toUpperCase() + k.slice(1)),
+      label: localizeDynamicText(k.charAt(0).toUpperCase() + k.slice(1), currentLang),
       value: gradeEmoji(g) + ' ' + gradeLabel(g),
       grade: g,
       detail: ''
@@ -6757,7 +6036,7 @@ export function renderDashboard(data, results, industrySelection = null) {
     <div id="${sec.id || `sec-${si}`}" class="section fade-up delay-${Math.min(si + 2, 6)}">
       <div class="section-head${si < 4 ? ' open' : ''}" onclick="toggleSection(this)">
         <span style="font-size:1.2rem">${sec.icon}</span>
-        <h3>${localizeDynamicText(sec.title)}</h3>
+        <h3>${localizeDynamicText(sec.title, currentLang)}</h3>
         <span class="metric-count">${sec.items.length} ${t('metricsAnalyzed', 'metrics analyzed')}</span>
         <span class="badge ${badgeCls}">${gradeLabel(sec.grade)}</span>
         <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
@@ -6785,15 +6064,15 @@ export function renderDashboard(data, results, industrySelection = null) {
       html += `
         <div class="a-item">
           <div>
-            <div class="metric-name">${localizeDynamicText(item.name)}${item.tip ? ` <span class="tip" data-tip="${localizeDynamicText(item.tip)}">ⓘ</span>` : ''} <span class="tip" data-tip="${t('scoreConditions', 'Score conditions')}: ${localizeDynamicText(item.scoreRule || item.explanation || item.signalText || '')}">🏷️</span></div>
-            ${renderMetricDetail(item.detail || '')}
-            ${item.explanation ? `<div class="metric-values">${localizeDynamicText(item.explanation)}</div>` : ''}
+            <div class="metric-name">${localizeDynamicText(item.name, currentLang)}${item.tip ? ` <span class="tip" data-tip="${localizeDynamicText(item.tip, currentLang)}">ⓘ</span>` : ''} <span class="tip" data-tip="${t('scoreConditions', 'Score conditions')}: ${localizeDynamicText(item.scoreRule || item.explanation || item.signalText || '', currentLang)}">🏷️</span></div>
+            ${renderMetricDetail(item.detail || '', currentLang)}
+            ${item.explanation ? `<div class="metric-values">${localizeDynamicText(item.explanation, currentLang)}</div>` : ''}
             <div class="metric-values">${t('confidence', 'Confidence')}: ${(item.confidence * 100).toFixed(0)}%</div>
             ${renderTrendBars(item.values?.fullValues || item.values, item.values?.fullLabels || item.labels || [])}
           </div>
           <div class="signal ${sigCls}">
             <span class="dot ${dotCls}"></span>
-            ${localizeDynamicText(item.signalText)}
+            ${localizeDynamicText(item.signalText, currentLang)}
           </div>
         </div>
       `;

--- a/src/domain/metrics/scoringDashboardRender.ts
+++ b/src/domain/metrics/scoringDashboardRender.ts
@@ -1,0 +1,253 @@
+// @ts-nocheck
+import {
+  localizeDynamicText,
+  renderMetricDetail,
+  renderPrintableMetricDetail
+} from './scoringLocalization';
+
+function gradeLabel(g, t) {
+  return (
+    {
+      excellent: t('excellent', 'Excellent'),
+      good: t('good', 'Good'),
+      average: t('average', 'Average'),
+      poor: t('poor', 'Poor'),
+      info: t('info', 'Info')
+    }[g] || g
+  );
+}
+
+function gradeBadgeClass(g) {
+  return (
+    {
+      excellent: 'badge-green',
+      good: 'badge-blue',
+      average: 'badge-yellow',
+      poor: 'badge-red',
+      info: 'badge-purple'
+    }[g] || 'badge-blue'
+  );
+}
+
+function gradeEmoji(g) {
+  return { excellent: '🟢', good: '🔵', average: '🟡', poor: '🔴' }[g] || '⚪';
+}
+
+function escapeHtml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function buildPrintableDashboardPanel(data, results, industrySelection = null, lang) {
+  const sectionBlocks = (results.sections || [])
+    .map((section) => {
+      const sectionTitle = `${section.icon || '•'} ${localizeDynamicText(section.title || '', lang)}`;
+      const metrics = (section.items || [])
+        .map((item) => {
+          const metricName = localizeDynamicText(item.name || 'Metric', lang);
+          const signalText = localizeDynamicText(item.signalText || '', lang);
+          const signal =
+            item.signal === 'bull'
+              ? lang === 'es'
+                ? '🟢 Positiva'
+                : '🟢 Positive'
+              : item.signal === 'bear'
+                ? lang === 'es'
+                  ? '🔴 Negativa'
+                  : '🔴 Negative'
+                : lang === 'es'
+                  ? '🟡 Neutral'
+                  : '🟡 Neutral';
+          const note = localizeDynamicText(item.note || '', lang);
+          const { headline, bulletHtml } = renderPrintableMetricDetail(
+            item,
+            lang,
+            escapeHtml
+          );
+          return `<li class="print-metric">
+            <div class="print-title">${escapeHtml(metricName)}</div>
+            ${headline ? `<div class="print-headline">${escapeHtml(headline)}</div>` : ''}
+            <ul class="print-bullets">${bulletHtml}</ul>
+            <div class="print-signal"><strong>${escapeHtml(lang === 'es' ? 'Señal:' : 'Signal:')}</strong> ${escapeHtml(signal)}${signalText ? ` · ${escapeHtml(signalText)}` : ''}</div>
+            ${note ? `<div class="print-note">${escapeHtml(note)}</div>` : ''}
+          </li>`;
+        })
+        .join('');
+      return `<section><h3>${escapeHtml(sectionTitle)}</h3><ul class="print-metrics">${metrics}</ul></section>`;
+    })
+    .join('');
+
+  const scoreLine = `${lang === 'es' ? 'Puntuación global' : 'Overall score'}: ${results.overallScore?.toFixed(1) || '-'} / 4.0`;
+  const industryLine = industrySelection
+    ? `${industrySelection.code} · ${industrySelection.name} (${industrySelection.profile})`
+    : lang === 'es'
+      ? 'Sin industria seleccionada'
+      : 'No selected industry';
+
+  return `<div class="printable-panel fade-up">
+    <div class="printable-header">
+      <h2>${escapeHtml(data.ticker ? `${data.ticker} — ${data.company}` : data.company)}</h2>
+      <p>${escapeHtml(data.period || '')}</p>
+      <p class="printable-help">${lang === 'es' ? 'Vista simplificada para imprimir. Puedes usar la impresión del navegador (Ctrl/Cmd+P).' : 'Simplified print-friendly view. Use your browser print dialog (Ctrl/Cmd+P).'}</p>
+    </div>
+    <div class="printable-summary">
+      <h3>${lang === 'es' ? 'Resumen rápido' : 'Quick summary'}</h3>
+      <p>${escapeHtml(scoreLine)}</p>
+      <p>${escapeHtml(lang === 'es' ? 'Industria:' : 'Industry:')} ${escapeHtml(industryLine)}</p>
+      <p>${escapeHtml(lang === 'es' ? `Métricas analizadas: ${results.totalMetrics}` : `Analyzed metrics: ${results.totalMetrics}`)}</p>
+    </div>
+    ${sectionBlocks}
+  </div>`;
+}
+
+function renderTrendBars(values, labels = []) {
+  const series = Array.isArray(values) ? values : [];
+  const points = Math.max(series.length, labels.length);
+  if (!points) return '';
+
+  const numeric = series.filter((v) => v !== null && v !== undefined && !isNaN(v));
+  const max = Math.max(...numeric.map((v) => Math.abs(v)), 1);
+  return `<div class="trend-bar">${Array.from({ length: points }, (_, i) => {
+      const v = series[i];
+      if (v === null || v === undefined || isNaN(v))
+        return '<div class="bar bar-missing"></div>';
+      const h = Math.max(2, (Math.abs(v) / max) * 30);
+      const cls = v > 0 ? 'bar-pos' : v < 0 ? 'bar-neg' : 'bar-zero';
+      const year = labels[i] || `#${i + 1}`;
+      const label = `${year}: ${v.toFixed(2)}`;
+      return `<button type="button" class="bar ${cls}" style="height:${h}px" title="${label}" aria-label="${label}" data-point="${label}"></button>`;
+    }).join('')}</div>`;
+}
+
+export function renderDashboardView(
+  data,
+  results,
+  industrySelection,
+  { lang, t, buildSummary, buildIndustryPanel, goBackAction = 'goBack()' }
+) {
+  const overallLabel = gradeLabel(results.overall || 'average', t);
+
+  let html = `
+    <div class="dash-header fade-up">
+      <div>
+        <h2>${data.ticker ? data.ticker + ' — ' : ''}${data.company}</h2>
+        <span class="price">${data.price || ''} ${data.period ? '• ' + localizeDynamicText(data.period, lang) : ''} • ${results.totalMetrics} ${t('metricsAnalyzed', 'metrics analyzed')}</span>
+      </div>
+      <div class="header-actions">
+        <button class="btn-toggle-sections" onclick="switchDashboardTab('print')">${lang === 'es' ? '🖨️ Imprimir' : '🖨️ Print'}</button>
+        <button id="toggleSectionsBtn" class="btn-toggle-sections" onclick="toggleAllSections()">${t('collapseAll', 'Collapse all sections')}</button>
+        <button class="btn-back" onclick="${goBackAction}">${t('newAnalysis', '← New Analysis')}</button>
+      </div>
+    </div>
+
+    <div class="dashboard-tabs fade-up delay-1">
+      <button class="dashboard-tab active" data-tab="analysis" onclick="switchDashboardTab('analysis')">${lang === 'es' ? 'Análisis' : 'Analysis'}</button>
+      <button class="dashboard-tab" data-tab="industry" onclick="switchDashboardTab('industry')">${lang === 'es' ? 'KPIs por industria' : 'Industry KPIs'}</button>
+      <button class="dashboard-tab" data-tab="print" onclick="switchDashboardTab('print')">${lang === 'es' ? '🖨️ Imprimible' : '🖨️ Printable'}</button>
+    </div>
+
+    <div class="dashboard-panel" data-panel="analysis">`;
+
+  const byId = (id) => results.sections.find((s) => s.id === id);
+  const catDefs = [
+    { k: 'Quality', sec: ['harmony', 'cashflow-truth', 'margins', 'cashflow'], href: '#harmony' },
+    { k: 'Moat', sec: ['moat', 'margins'], href: '#moat' },
+    { k: 'Financial Risk', sec: ['balance', 'balance-composition', 'debt'], href: '#balance' },
+    { k: 'Valuation', sec: ['valuation', 'valuation-philosophy'], href: '#valuation-philosophy' }
+  ];
+  html += `<div class="score-row">`;
+  catDefs.forEach((cat) => {
+    const found = cat.sec.map(byId).filter(Boolean);
+    const signals = found.flatMap((f) => f.items || []);
+    const bears = signals.filter((i) => i.signal === 'bear').length;
+    const bulls = signals.filter((i) => i.signal === 'bull').length;
+    const grade = bears >= 2 ? 'poor' : bulls > bears ? 'good' : 'average';
+    const driver = localizeDynamicText(signals[0]?.name || 'Not enough data', lang);
+    const light = grade === 'poor' ? '🔴' : grade === 'good' ? '🟢' : '🟡';
+    html += `<div class="score-card ${grade} fade-up"><div class="label">${localizeDynamicText(`2-minute ${cat.k}`, lang)}</div><div class="value">${light} ${gradeLabel(grade, t)}</div><div class="detail">${driver} · <a href="${cat.href}" style="color:var(--accent)">${localizeDynamicText('see details', lang)}</a></div></div>`;
+  });
+  html += `</div>`;
+
+  const cards = [
+    {
+      label: localizeDynamicText('Overall Health', lang),
+      value: overallLabel,
+      grade: results.overall,
+      detail: `${lang === 'es' ? 'Puntuación' : 'Score'}: ${results.overallScore?.toFixed(1)}/4.0`
+    },
+    ...Object.entries(results.scores).map(([k, g]) => ({
+      label: localizeDynamicText(k.charAt(0).toUpperCase() + k.slice(1), lang),
+      value: gradeEmoji(g) + ' ' + gradeLabel(g, t),
+      grade: g,
+      detail: ''
+    }))
+  ];
+
+  html += `<div class="score-row">`;
+  cards.forEach((c, i) => {
+    html += `<div class="score-card ${c.grade} fade-up delay-${Math.min(i + 1, 6)}">
+      <div class="label">${c.label}</div>
+      <div class="value">${c.value}</div>
+      ${c.detail ? `<div class="detail">${c.detail}</div>` : ''}
+    </div>`;
+  });
+  html += `</div>`;
+
+  results.sections.forEach((sec, si) => {
+    const badgeCls = gradeBadgeClass(sec.grade);
+    html += `
+    <div id="${sec.id || `sec-${si}`}" class="section fade-up delay-${Math.min(si + 2, 6)}">
+      <div class="section-head${si < 4 ? ' open' : ''}" onclick="toggleSection(this)">
+        <span style="font-size:1.2rem">${sec.icon}</span>
+        <h3>${localizeDynamicText(sec.title, lang)}</h3>
+        <span class="metric-count">${sec.items.length} ${t('metricsAnalyzed', 'metrics analyzed')}</span>
+        <span class="badge ${badgeCls}">${gradeLabel(sec.grade, t)}</span>
+        <svg class="chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="6 9 12 15 18 9"/></svg>
+      </div>
+      <div class="section-body">
+        <div class="analysis-grid">
+    `;
+    sec.items.forEach((item) => {
+      const sigCls =
+        item.signal === 'bull'
+          ? 'signal-bull'
+          : item.signal === 'bear'
+            ? 'signal-bear'
+            : item.signal === 'info'
+              ? 'signal-info'
+              : 'signal-neutral';
+      const dotCls =
+        item.signal === 'bull'
+          ? 'dot-green'
+          : item.signal === 'bear'
+            ? 'dot-red'
+            : item.signal === 'info'
+              ? 'dot-blue'
+              : 'dot-yellow';
+      html += `
+        <div class="a-item">
+          <div>
+            <div class="metric-name">${localizeDynamicText(item.name, lang)}${item.tip ? ` <span class="tip" data-tip="${localizeDynamicText(item.tip, lang)}">ⓘ</span>` : ''} <span class="tip" data-tip="${t('scoreConditions', 'Score conditions')}: ${localizeDynamicText(item.scoreRule || item.explanation || item.signalText || '', lang)}">🏷️</span></div>
+            ${renderMetricDetail(item.detail || '', lang)}
+            ${item.explanation ? `<div class="metric-values">${localizeDynamicText(item.explanation, lang)}</div>` : ''}
+            <div class="metric-values">${t('confidence', 'Confidence')}: ${(item.confidence * 100).toFixed(0)}%</div>
+            ${renderTrendBars(item.values?.fullValues || item.values, item.values?.fullLabels || item.labels || [])}
+          </div>
+          <div class="signal ${sigCls}">
+            <span class="dot ${dotCls}"></span>
+            ${localizeDynamicText(item.signalText, lang)}
+          </div>
+        </div>
+      `;
+    });
+    html += `</div></div></div>`;
+  });
+
+  html += buildSummary(data, results);
+  html += `</div><div class="dashboard-panel" data-panel="industry" style="display:none">${buildIndustryPanel(data, results, industrySelection)}</div><div class="dashboard-panel" data-panel="print" style="display:none">${buildPrintableDashboardPanel(data, results, industrySelection, lang)}</div>`;
+  return html;
+}

--- a/src/domain/metrics/scoringDashboardUi.ts
+++ b/src/domain/metrics/scoringDashboardUi.ts
@@ -1,0 +1,43 @@
+export function switchDashboardTabUi(tab: string) {
+  document
+    .querySelectorAll<HTMLElement>('.dashboard-tab')
+    .forEach((btn) => btn.classList.toggle('active', btn.dataset.tab === tab));
+
+  document.querySelectorAll<HTMLElement>('.dashboard-panel').forEach((panel) => {
+    panel.style.display = panel.dataset.panel === tab ? 'block' : 'none';
+  });
+}
+
+export function updateToggleSectionsButtonUi(
+  collapseText: string,
+  openText: string
+) {
+  const btn = document.getElementById('toggleSectionsBtn');
+  if (!btn) return;
+
+  const heads = Array.from(document.querySelectorAll<HTMLElement>('.section-head'));
+  if (!heads.length) {
+    btn.textContent = openText;
+    return;
+  }
+
+  const allOpen = heads.every((h) => h.classList.contains('open'));
+  btn.textContent = allOpen ? collapseText : openText;
+}
+
+export function toggleSectionUi(
+  headEl: HTMLElement,
+  onToggle: () => void
+) {
+  headEl.classList.toggle('open');
+  onToggle();
+}
+
+export function toggleAllSectionsUi(onToggle: () => void) {
+  const heads = Array.from(document.querySelectorAll<HTMLElement>('.section-head'));
+  if (!heads.length) return;
+
+  const allOpen = heads.every((h) => h.classList.contains('open'));
+  heads.forEach((h) => h.classList.toggle('open', !allOpen));
+  onToggle();
+}

--- a/src/domain/metrics/scoringLocalization.test.ts
+++ b/src/domain/metrics/scoringLocalization.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  canonicalizeFinancialLabel,
+  localizeDynamicText,
+  normalizeLabelText,
+  renderMetricDetail,
+  renderPrintableMetricDetail,
+  translateFinancialLabel
+} from './scoringLocalization';
+
+describe('scoringLocalization', () => {
+  it('normalizes labels with whitespace and typo fixes', () => {
+    expect(normalizeLabelText('  inmobilizado\u00A0  bruto ')).toBe('inmovilizado bruto');
+    expect(normalizeLabelText('beneficio  netos')).toBe('beneficio neto');
+    expect(normalizeLabelText('margen % )')).toBe('margen %)');
+  });
+
+  it('canonicalizes english, spanish and synonym labels', () => {
+    expect(canonicalizeFinancialLabel('Gross Profit')).toMatchObject({
+      canonicalEn: 'Gross Profit',
+      es: 'Beneficio bruto',
+      match: 'exact_en'
+    });
+
+    expect(canonicalizeFinancialLabel('Beneficio bruto')).toMatchObject({
+      canonicalEn: 'Gross Profit',
+      match: 'exact_es'
+    });
+
+    expect(canonicalizeFinancialLabel('capital expenditures')).toMatchObject({
+      canonicalEn: 'Capital Expenditure',
+      match: 'synonym'
+    });
+  });
+
+  it('translates financial labels based on target language', () => {
+    expect(translateFinancialLabel('Gross Profit', 'es')).toBe('Beneficio bruto');
+    expect(translateFinancialLabel('Beneficio bruto', 'en')).toBe('Gross Profit');
+  });
+
+  it('localizes known metric/fragment tokens but keeps larger words intact', () => {
+    const translated = localizeDynamicText(
+      'Operating Leverage is up while supplier remains supported',
+      'es'
+    );
+
+    expect(translated).toContain('Apalancamiento operativo');
+    expect(translated).toContain('al alza');
+    expect(translated).toContain('supplier');
+    expect(translated).toContain('supported');
+    expect(translated).not.toContain('al alzapplier');
+  });
+
+  it('renders structured metric detail into details/summary/list blocks', () => {
+    const html = renderMetricDetail(
+      'Revenue YoY Growth • Interpretation: stable execution • Trend: up',
+      'es'
+    );
+
+    expect(html).toContain('<details class="metric-detail">');
+    expect(html).toContain('<span class="md-kpi">Crecimiento interanual de ingresos</span>');
+    expect(html).toContain('<span class="md-interpret">estable execution</span>');
+    expect(html).toContain('<span class="md-label">Tendencia:</span> al alza');
+  });
+
+  it('renders simple metric detail without details wrapper when not structured', () => {
+    const html = renderMetricDetail('Operating Leverage', 'es');
+    expect(html).toBe('<div class="metric-detail">Apalancamiento operativo</div>');
+  });
+
+  it('renders printable detail with escaped labels/values and explanation', () => {
+    const { headline, bulletHtml } = renderPrintableMetricDetail(
+      {
+        detail:
+          'Revenue YoY Growth • Interpretation: <script>alert(1)</script> • Trend: up',
+        explanation: 'Gross Profit: 42%'
+      },
+      'en',
+      (value: string) =>
+        value
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+    );
+
+    expect(headline).toContain('Revenue YoY Growth');
+    expect(bulletHtml).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+    expect(bulletHtml).toContain('<strong>Trend:</strong> up');
+    expect(bulletHtml).toContain('<strong>Data:</strong> Gross Profit: 42%');
+  });
+
+  it('returns default printable bullet when metric has no detail or explanation', () => {
+    const { bulletHtml } = renderPrintableMetricDetail(
+      { detail: '', explanation: '' },
+      'es',
+      (value: string) => value
+    );
+
+    expect(bulletHtml).toContain('Sin detalle adicional.');
+  });
+});

--- a/src/domain/metrics/scoringLocalization.ts
+++ b/src/domain/metrics/scoringLocalization.ts
@@ -1,0 +1,732 @@
+// @ts-nocheck
+
+const FINANCIAL_LABEL_EN_ES = {
+  Revenues: 'Ingresos',
+  'Total Revenues': 'Ingresos totales',
+  '% Change YoY': '% De cambio interanual',
+  'Cost of Goods Sold': 'Coste de los bienes vendidos',
+  'Gross Profit': 'Beneficio bruto',
+  '% Gross Margins': '% Márgenes brutos',
+  'Selling General & Admin Expenses':
+    'Gastos de venta generales y administrativos',
+  'Depreciation & Amortization': 'Depreciación y amortización',
+  'Amortization of Goodwill and Intangible Assets':
+    'Amortización de fondos de comercio y activos intangibles',
+  'Other Operating Expenses': 'Otros gastos operacionales',
+  'Total Operating Expenses': 'Gastos operativos totales',
+  'Operating Income': 'Beneficio operativo',
+  '% Operating Margins': '% Márgenes operativos',
+  'Interest Expense': 'Gastos por intereses',
+  'Interest And Investment Income': 'Ingresos por intereses e inversiones',
+  'Currency Exchange Gains (Loss)': 'Ganancias (pérdidas) cambiarias',
+  'Other Non Operating Income (Expenses)':
+    'Otros ingresos (gastos) no operativos',
+  'EBT Excl. Unusual Items': 'EBT excl. Artículos inusuales',
+  'Merger & Restructuring Charges': 'Cargos de fusión y reestructuración',
+  'Impairment of Goodwill': 'Deterioro del fondo de comercio',
+  'Gain (Loss) On Sale Of Investments':
+    'Ganancia (pérdida) por venta de inversiones',
+  'Legal Settlements': 'Acuerdos legales',
+  'Other Unusual Items': 'Otros artículos inusuales',
+  'EBT Incl. Unusual Items': 'EBT incl. Artículos extraordinarios',
+  'Income Tax Expense': 'Gastos de impuestos',
+  'Earnings From Continuing Operations':
+    'Beneficios por operaciones continuadas',
+  'Net Income to Company': 'Beneficio neto de la empresa',
+  'Net Income': 'Beneficio neto',
+  'Preferred Dividend and Other Adjustments':
+    'Dividendo preferente y otros ajustes',
+  'Net Income to Common Incl Extra Items':
+    'Beneficio neto a acciones comunes incluidos extraordinarios',
+  '% Net Income to Common Incl Extra Items Margins':
+    'Margen de beneficio neto a acciones comunes incluidos extraordinarios %',
+  'Net Income to Common Excl. Extra Items':
+    'Beneficio neto a acciones comunes excluidos extraordinarios',
+  '% Net Income to Common Excl. Extra Items Margins':
+    'Margen de beneficio neto a acciones comunes excluidos extraordinarios %',
+  'Supplementary Data:': 'Datos adicionales:',
+  'Diluted EPS Excl Extra Items': 'BPA diluido sin extraordinarios',
+  'Weighted Average Diluted Shares Outstanding':
+    'Promedio ponderado de acciones diluidas en circulación',
+  'Weighted Average Basic Shares Outstanding':
+    'Promedio ponderado de acciones básicas en circulación',
+  'Basic EPS': 'BPA básico',
+  EBITDA: 'EBITDA',
+  EBITDAR: 'EBITDAR',
+  'Selling and Marketing Expense': 'Gastos de venta y marketing',
+  'Effective Tax Rate %': 'Tasa efectiva de impuestos %',
+  'Market Cap': 'Capitalización de mercado',
+  'Price Close': 'Precio de cierre',
+  TEV: 'TEV',
+  'Cash And Equivalents': 'Efectivo y equivalentes',
+  'Total Cash And Short Term Investments':
+    'Efectivo total e inversiones a corto plazo',
+  'Accounts Receivable': 'Cuentas por cobrar',
+  'Other Receivables': 'Otros por cobrar',
+  'Notes Receivable': 'Notas por cobrar',
+  'Total Receivables': 'Total de cuentas por cobrar',
+  'Prepaid Expenses': 'Gastos pagados por anticipado',
+  'Restricted Cash': 'Efectivo restringido',
+  'Other Current Assets': 'Otro activo corriente',
+  'Total Current Assets': 'Total de activo corriente',
+  'Gross Property Plant And Equipment': 'Inmovilizado material bruto',
+  'Accumulated Depreciation': 'Depreciación acumulada',
+  'Net Property Plant And Equipment': 'Inmovilizado material neto',
+  Goodwill: 'Fondo de comercio',
+  'Other Intangibles': 'Otros intangibles',
+  'Deferred Tax Assets Long-Term':
+    'Activos por impuestos diferidos a largo plazo',
+  'Deferred Charges Long-Term': 'Cargos diferidos a largo plazo',
+  'Other Long-Term Assets': 'Otros activos a largo plazo',
+  'Total Assets': 'Activo total',
+  'Accounts Payable': 'Cuentas por pagar',
+  'Accrued Expenses': 'Gastos devengados',
+  'Short-term Borrowings': 'Préstamos de corto plazo',
+  'Current Portion of Long-Term Debt':
+    'Porción corriente de la deuda a largo plazo',
+  'Current Portion of Capital Lease Obligations':
+    'Porción corriente de las obligaciones de arrendamiento financiero',
+  'Unearned Revenue Current': 'Ingresos no devengados (corriente)',
+  'Other Current Liabilities': 'Otros pasivos corrientes',
+  'Total Current Liabilities': 'Total pasivo corriente',
+  'Long-Term Debt': 'Deuda a largo plazo',
+  'Capital Leases': 'Arrendamientos de capitales',
+  'Deferred Tax Liability Non Current':
+    'Pasivo por impuesto diferido no corriente',
+  'Other Non Current Liabilities': 'Otro pasivo no corrientes',
+  'Total Liabilities': 'Pasivo Total',
+  'Common Stock': 'Acciones comunes',
+  'Additional Paid In Capital': 'Prima de suscripción',
+  'Retained Earnings': 'Beneficio no distribuido',
+  'Treasury Stock': 'Autocartera',
+  'Comprehensive Income and Other': 'Resultado integral y otros',
+  'Total Common Equity': 'Patrimonio neto común total',
+  'Total Equity': 'Fondos propios totales',
+  'Total Liabilities And Equity': 'Pasivo total y patrimonio neto',
+  'Total Shares Out. on Filing Date':
+    'Total de acciones fuera. en la fecha de presentación',
+  'Book Value / Share': 'Valor contable / Acción',
+  'Tangible Book Value': 'Valor contable tangible',
+  'Tangible Book Value / Share': 'Valor contable tangible / acción',
+  'Total Debt': 'Deuda total',
+  'Net Debt': 'Deuda neta',
+  Land: 'Terrenos',
+  Buildings: 'Edificios',
+  'Construction In Progress': 'Construcción en progreso',
+  'Full Time Employees': 'Empleados a tiempo completo',
+  'Cash Flow Statement': 'Estado de flujo de efectivo',
+  'Total Depreciation & Amortization': 'Depreciación y amortización total',
+  'Amortization of Deferred Charges': 'Amortización de cargos diferidos',
+  '(Gain) Loss on Sale of Investments':
+    '(Ganancia) Pérdida por venta de inversiones',
+  'Asset Writedown & Restructuring Costs':
+    'Deterioro de activos y costes de reestructuración',
+  'Stock-Based Compensation': 'Compensación de stock options',
+  'Other Operating Activities': 'Otras actividades operativas',
+  'Change In Accounts Receivable': 'Cambio en cuentas por cobrar',
+  'Change In Accounts Payable': 'Cambio en cuentas por pagar',
+  'Change in Unearned Revenues': 'Cambio en los ingresos no devengados',
+  'Change in Other Net Operating Assets':
+    'Variación en otros activos operativos netos',
+  'Cash from Operations': 'Efectivo de Operaciones',
+  'Memo: Change in Net Working Capital':
+    'Nota: Cambio en el capital circulante',
+  'Capital Expenditure': 'Gastos de capital',
+  'Cash Acquisitions': 'Adquisiciones con efectivo',
+  'Sale (Purchase) of Intangible assets':
+    'Venta (compra) de activos intangibles',
+  'Other Investing Activities': 'Otras actividades de inversión',
+  'Cash from Investing': 'Efectivo de la inversión',
+  'Total Debt Issued': 'Deuda total emitida',
+  'Total Debt Repaid': 'Total de la deuda reembolsada',
+  'Issuance of Common Stock': 'Emisión de acciones ordinarias',
+  'Repurchase of Common Stock': 'Recompra de acciones comunes',
+  'Other Financing Activities': 'Otras Actividades de Financiamiento',
+  'Cash from Financing': 'Efectivo de Financiamiento',
+  'Foreign Exchange Rate Adjustments': 'Ajustes del tipo de cambio de divisas',
+  'Net Change in Cash': 'Cambio neto en efectivo',
+  'Free Cash Flow': 'Flujo de caja libre',
+  '% Free Cash Flow Margins': '% Márgenes de flujo de caja libre',
+  'Cash and Cash Equivalents, Beginning of Period':
+    'Efectivo y equivalentes de efectivo, comienzo del período',
+  'Cash and Cash Equivalents, End of Period':
+    'Efectivo y equivalentes de efectivo, fin de período',
+  'Cash Interest Paid': 'Intereses en efectivo pagados',
+  'Cash Taxes Paid': 'Impuestos en efectivo pagados',
+  'Cash Flow per Share': 'Flujo de caja por acción'
+};
+
+const FINANCIAL_SYNONYMS = {
+  sga: 'Selling General & Admin Expenses',
+  'sg&a': 'Selling General & Admin Expenses',
+  'selling general & admin': 'Selling General & Admin Expenses',
+  'selling general and admin': 'Selling General & Admin Expenses',
+  'selling, general & administrative': 'Selling General & Admin Expenses',
+  'selling general & administrative': 'Selling General & Admin Expenses',
+  'cash and cash equivalents': 'Cash And Equivalents',
+  'capital expenditures': 'Capital Expenditure',
+  'capital expenditure': 'Capital Expenditure',
+  'unearned revenue current': 'Unearned Revenue Current'
+};
+
+const LABEL_NORMALIZATION_FIXES = {
+  inmobilizado: 'inmovilizado',
+  'beneficio netos': 'beneficio neto',
+  extradordinarios: 'extraordinarios'
+};
+
+const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const LABEL_FIX_PATTERNS = Object.entries(LABEL_NORMALIZATION_FIXES).map(
+  ([wrong, ok]) => [new RegExp(escapeRegExp(wrong), 'gi'), ok]
+);
+
+export function normalizeLabelText(label) {
+  if (!label) return '';
+  let out = String(label)
+    .replace(/\u00A0/g, ' ')
+    .replace(/\s+/g, ' ')
+    .replace(/\s*%\s*/g, ' % ')
+    .trim();
+  LABEL_FIX_PATTERNS.forEach(([re, ok]) => {
+    out = out.replace(re, ok);
+  });
+  return out.replace(/%\s+\)/g, '%)').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeSentenceText(text) {
+  return String(text ?? '')
+    .replace(/\u00A0/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const FINANCIAL_LABEL_NORMALIZED_EN = Object.fromEntries(
+  Object.entries(FINANCIAL_LABEL_EN_ES).map(([en, es]) => [
+    normalizeLabelText(en).toLowerCase(),
+    { en, es }
+  ])
+);
+
+const FINANCIAL_LABEL_NORMALIZED_ES = Object.fromEntries(
+  Object.entries(FINANCIAL_LABEL_EN_ES).map(([en, es]) => [
+    normalizeLabelText(es).toLowerCase(),
+    { en, es }
+  ])
+);
+
+export function canonicalizeFinancialLabel(label) {
+  const raw = String(label || '');
+  const normalized = normalizeLabelText(raw);
+  const key = normalized.toLowerCase();
+  const exactEn = FINANCIAL_LABEL_NORMALIZED_EN[key];
+  if (exactEn)
+    return {
+      raw,
+      normalized,
+      canonicalEn: exactEn.en,
+      es: exactEn.es,
+      match: 'exact_en'
+    };
+
+  const exactEs = FINANCIAL_LABEL_NORMALIZED_ES[key];
+  if (exactEs)
+    return {
+      raw,
+      normalized,
+      canonicalEn: exactEs.en,
+      es: exactEs.es,
+      match: 'exact_es'
+    };
+
+  const syn = FINANCIAL_SYNONYMS[normalized.toLowerCase()];
+  if (syn && FINANCIAL_LABEL_EN_ES[syn]) {
+    return {
+      raw,
+      normalized,
+      canonicalEn: syn,
+      es: FINANCIAL_LABEL_EN_ES[syn],
+      match: 'synonym'
+    };
+  }
+
+  return { raw, normalized, canonicalEn: raw, es: raw, match: 'fallback' };
+}
+
+export function translateFinancialLabel(label, lang) {
+  const c = canonicalizeFinancialLabel(label);
+  return lang === 'es' ? c.es || c.raw : c.canonicalEn || c.raw;
+}
+
+const DYNAMIC_I18N = {
+  sectionTitles: {
+    Growth: 'Crecimiento',
+    'Profitability & Margins': 'Rentabilidad y Márgenes',
+    'Cost Structure & OpEx': 'Estructura de Costes y OpEx',
+    'Returns & Economic Moat': 'Retornos y Foso Económico',
+    'Balance Sheet Composition': 'Composición del Balance',
+    'Debt & Financial Health': 'Deuda y Salud Financiera',
+    'Cash Flow Quality': 'Calidad del Flujo de Caja',
+    'Efficiency & Operations': 'Eficiencia y Operaciones',
+    Valuation: 'Valoración',
+    'Dividends & Shareholder Returns': 'Dividendos y Retorno al Accionista',
+    'Consensus Estimates': 'Estimaciones de Consenso',
+    'Analyst Sentiment (Low weight / noisy — ruido)':
+      'Sentimiento de Analistas (bajo peso / ruidoso)',
+    'Harmony & Red Flags': 'Armonía y Banderas Rojas',
+    'Balance Sheet Reality Check': 'Chequeo de Realidad del Balance',
+    'Cash Flow — The Truth Serum': 'Flujo de Caja — Suero de la Verdad'
+  },
+  metricNames: {
+    'Current Ratio': 'Ratio Corriente',
+    'Quick Ratio': 'Ratio Rápido',
+    'Revenue Growth (CAGR)': 'Crecimiento de Ingresos (CAGR)',
+    'Revenue YoY Growth': 'Crecimiento interanual de ingresos',
+    'EPS Growth (Diluted)': 'Crecimiento del BPA (diluido)',
+    'EBITDA Growth': 'Crecimiento del EBITDA',
+    'Operating Income Growth': 'Crecimiento del beneficio operativo',
+    'Net Income Growth': 'Crecimiento del beneficio neto',
+    'Free Cash Flow Growth': 'Crecimiento del flujo de caja libre',
+    'Gross Margin': 'Margen bruto',
+    'Operating Margin (EBIT)': 'Margen operativo (EBIT)',
+    'EBITDA Margin': 'Margen EBITDA',
+    'FCF Margin': 'Margen de FCF',
+    'Margin Expansion vs Gross': 'Expansión de márgenes vs bruto',
+    'Operating Leverage': 'Apalancamiento operativo',
+    'COGS as % of Revenue': 'COGS como % de ingresos',
+    'Operating Expenses as % of Gross Profit':
+      'Gastos operativos como % del beneficio bruto',
+    'SG&A as % of Revenue': 'SG&A como % de ingresos',
+    'R&D as % of Revenue': 'I+D como % de ingresos',
+    'Effective Tax Rate': 'Tasa efectiva de impuestos',
+    'Interest Expense as % of Revenue':
+      'Gastos por intereses como % de ingresos',
+    'Stock-Based Comp as % of Revenue':
+      'Compensación en acciones como % de ingresos',
+    'ROIC (Return on Invested Capital)':
+      'ROIC (Retorno sobre Capital Invertido)',
+    'ROE (Return on Equity)': 'ROE (Retorno sobre Patrimonio)',
+    'ROA (Return on Assets)': 'ROA (Retorno sobre Activos)',
+    'Equity Multiplier (ROE/ROA)': 'Multiplicador de patrimonio (ROE/ROA)',
+    'Asset Turnover': 'Rotación de activos',
+    'Receivables Turnover': 'Rotación de cuentas por cobrar',
+    'Inventory Turnover': 'Rotación de inventarios',
+    'Cash Conversion Cycle': 'Ciclo de conversión de caja',
+    'Days Sales Outstanding (DSO)': 'Días de ventas pendientes (DSO)',
+    'Enterprise Value vs Market Cap':
+      'Enterprise Value vs Capitalización de mercado',
+    'Forward P/E (NTM)': 'P/E futuro (NTM)',
+    'Price / Sales': 'Precio / Ventas',
+    'Price / Book Value': 'Precio / Valor contable',
+    'EV/EBITDA (NTM)': 'EV/EBITDA (NTM)',
+    'EV/EBIT': 'EV/EBIT',
+    'FCF Yield (NTM)': 'Rentabilidad FCF (NTM)',
+    'Dividend Yield': 'Rentabilidad por dividendo',
+    'P/E Context Map (informational)': 'Mapa de contexto P/E (informativo)',
+    'Dividends Per Share': 'Dividendos por acción',
+    'Payout Ratio': 'Payout ratio',
+    'Total Dividends Paid': 'Dividendos totales pagados',
+    'Share Buybacks': 'Recompras de acciones',
+    'Share Issuance (Dilution)': 'Emisión de acciones (dilución)',
+    'Diluted Shares Outstanding': 'Acciones diluidas en circulación',
+    'Total Shareholder Yield': 'Retorno total al accionista',
+    'Consensus Revenue Estimate': 'Estimación de ingresos de consenso',
+    'Consensus EPS Estimate': 'Estimación de BPA de consenso',
+    'Consensus EBITDA Estimate': 'Estimación de EBITDA de consenso',
+    'Consensus FCF Estimate': 'Estimación de FCF de consenso',
+    'Revenue vs Earnings Harmony': 'Armonía ingresos vs beneficios',
+    'CFO vs Net Income (Accrual Risk, LTM)':
+      'CFO vs Beneficio neto (riesgo de devengo)',
+    'FCF Consistency Check': 'Chequeo de consistencia del FCF',
+    'Net Debt / Net Cash': 'Deuda neta / Caja neta',
+    'Cash / Short-Term Debt': 'Caja / Deuda a corto plazo',
+    'Receivables Days Trend': 'Tendencia de días de cobro',
+    'Inventory vs Revenue Growth': 'Crecimiento inventario vs ingresos',
+    'Goodwill + Intangibles Concentration':
+      'Concentración de fondo de comercio + intangibles',
+    'Deferred Revenue Signal': 'Señal de ingresos diferidos',
+    'FCF Uses Summary': 'Resumen de usos del FCF',
+    'SBC as % of FCF': 'SBC como % del FCF',
+    'SBC as % of Net Income': 'SBC como % del beneficio neto'
+  },
+  fragments: {
+    Latest: 'Último',
+    Avg: 'Promedio',
+    Trend: 'Tendencia',
+    'Insufficient data': 'Datos insuficientes',
+    Strong: 'Fuerte',
+    Moderate: 'Moderado',
+    Slow: 'Lento',
+    Declining: 'En descenso',
+    'Very Liquid': 'Muy líquido',
+    Healthy: 'Saludable',
+    OK: 'Correcto',
+    'Low Liquidity ⚠️': 'Liquidez baja ⚠️',
+    'Excludes inventory — more conservative than current ratio':
+      'Excluye inventario: más conservador que el ratio corriente',
+    'Very Healthy': 'Muy saludable',
+    Adequate: 'Adecuado',
+    'Tight Liquidity ⚠️': 'Liquidez ajustada ⚠️',
+    'Not enough data': 'Datos insuficientes',
+    'see details': 'ver detalle',
+    Quality: 'Calidad',
+    Moat: 'Foso',
+    'Financial Risk': 'Riesgo Financiero',
+    'Overall Health': 'Salud General',
+    Valuation: 'Valoración',
+    Growth: 'Crecimiento',
+    Margins: 'Márgenes',
+    Costs: 'Costes',
+    Balance: 'Balance',
+    Debt: 'Deuda',
+    Cashflow: 'Flujo de caja',
+    Efficiency: 'Eficiencia',
+    Shareholder: 'Accionista',
+    Harmony: 'Armonía',
+    Good: 'Bueno',
+    Excellent: 'Excelente',
+    Average: 'Medio',
+    Poor: 'Débil',
+    Volatile: 'Volátil',
+    Decent: 'Decente',
+    'Best-in-class': 'Líder de clase',
+    Elite: 'Élite',
+    'Cash Machine': 'Máquina de caja',
+    'Some Leverage': 'Algo de apalancamiento',
+    'Investing in Innovation': 'Invirtiendo en innovación',
+    Outstanding: 'Sobresaliente',
+    'Negative CCC (Uses supplier float!)':
+      'CCC negativo (usa financiación de proveedores)',
+    'Strong supplier float (supplier financing)':
+      'Fuerte supplier float (financiación de proveedores)',
+    'Low payables float': 'Float de proveedores bajo',
+    'Context only': 'Solo contexto',
+    'Never Cut — Reliable': 'Nunca recortado — fiable',
+    'In line': 'En línea',
+    Manageable: 'Manejable',
+    Contained: 'Contenido',
+    Acceptable: 'Aceptable',
+    'Aligned Growth': 'Crecimiento alineado',
+    'Cash-backed earnings': 'Beneficios respaldados por caja',
+    Neutral: 'Neutral',
+    Covered: 'Cubierto',
+    Stable: 'Estable',
+    Limited: 'Limitado',
+    Fair: 'Razonable',
+    Expensive: 'Caro',
+    'Very Rich': 'Muy exigente',
+    Rich: 'Exigente',
+    'Token Dividend': 'Dividendo simbólico',
+    'Very Safe': 'Muy seguro',
+    'Growing Distributions': 'Distribuciones crecientes',
+    'Active Buybacks': 'Recompras activas',
+    'Heavy Dilution ⚠️': 'Fuerte dilución ⚠️',
+    'Shrinking ✓': 'Reduciéndose ✓',
+    'Excellent Capital Return': 'Excelente retorno de capital',
+    annual: 'anual',
+    '2-minute Quality': 'Calidad en 2 minutos',
+    '2-minute Moat': 'Foso en 2 minutos',
+    '2-minute Financial Risk': 'Riesgo financiero en 2 minutos',
+    '2-minute Valuation': 'Valoración en 2 minutos',
+    'Return on Equity': 'Retorno sobre el patrimonio',
+    'Return on Assets': 'Retorno sobre activos',
+    'Enterprise Value vs Capitalización de mercado':
+      'Valor de empresa (EV) vs capitalización de mercado',
+    'Enterprise Value vs Market Cap':
+      'Valor de empresa (EV) vs capitalización de mercado',
+    'Revenue vs Earnings Harmony': 'Armonía entre ingresos y beneficios',
+    Revenue: 'ingresos',
+    Earnings: 'beneficios',
+    'Revenue YoY': 'Ingresos interanuales (YoY)',
+    'Earnings YoY': 'Beneficios interanuales (YoY)',
+    'Std dev': 'desviación estándar',
+    'erratic growth': 'crecimiento errático',
+    'Net Profit Margin': 'Margen de beneficio neto',
+    Exceptional: 'Excepcional',
+    Stability: 'Estabilidad',
+    stable: 'estable',
+    up: 'al alza',
+    'Gross Δ': 'Δ (cambio) bruto',
+    'Op Δ': 'Δ (cambio) operativo',
+    'Watch for cost structure issues':
+      'Vigila posibles problemas en la estructura de costes',
+    'Operating Expenses as % of Beneficio bruto':
+      'Gastos operativos como % del beneficio bruto',
+    'Golden rule: OpEx should not eat most gross profit (gastos operativos controlados).':
+      'Regla de oro: el OpEx no debería comerse la mayor parte del beneficio bruto (gastos operativos controlados).',
+    Controlled: 'Controlado',
+    'SG&A': 'Gastos de venta, generales y administrativos (SG&A)',
+    'Lower is better — shows operational efficiency':
+      'Cuanto más bajo, mejor — indica eficiencia operativa',
+    Minimal: 'Mínimo',
+    'Beware: high leverage can inflate ROE artificially':
+      'Ojo: un apalancamiento alto puede inflar el ROE artificialmente',
+    'Equity Multiplier': 'Multiplicador del patrimonio (apalancamiento)',
+    'Leverage-driven ROE': 'ROE impulsado por apalancamiento',
+    Leveraged: 'Apalancada / con alto apalancamiento',
+    'Private equity stress threshold is typically 4-5x':
+      'El umbral de estrés típico en private equity suele ser 4–5x',
+    'Very Low Debt': 'Deuda muy baja',
+    'Very Low Deuda': 'Deuda muy baja',
+    'Very Efficient': 'Muy eficiente',
+    'Excellent Collection': 'Excelente gestión de cobros',
+    'Negative CCC = the business generates cash before paying suppliers (very powerful)':
+      'CCC negativo = el negocio genera efectivo antes de pagar a proveedores (muy potente)',
+    'Buybacks reduce share count and boost EPS':
+      'Las recompras reducen el número de acciones y elevan el BPA (EPS)',
+    'Fewer shares = more value per share for existing holders':
+      'Menos acciones = más valor por acción para los accionistas actuales',
+    'Buybacks + dividends as % of market cap':
+      'Recompras + dividendos como % de la capitalización bursátil',
+    'Aligned Crecimiento': 'Crecimiento alineado',
+    Aligned: 'Alineado',
+    'Healthy conversion': 'Conversión saludable',
+    Disciplined: 'Disciplinado',
+    'Capital allocation context': 'Contexto de asignación de capital',
+    'Classic heuristic: net margin >10% good, >20% excellent (sector-aware).':
+      'Heurística clásica: margen neto >10% es bueno, >20% es excelente (dependiendo del sector).',
+    'Classic heuristic: net margin >10 % good, >20 % excellent (sector-aware).':
+      'Heurística clásica: margen neto >10% es bueno, >20% es excelente (dependiendo del sector).',
+    'Gross vs Net Margin': 'Margen bruto vs margen neto',
+    'Operating Discipline': 'Disciplina operativa',
+    'If gross margin is stable but operating margin falls, overhead is eating profitability.':
+      'Si el margen bruto se mantiene estable pero cae el margen operativo, los costes fijos/estructura se están comiendo la rentabilidad.',
+    FCF: 'flujo de caja libre (FCF)',
+    'Revenue trend: up | Earnings trend: stable | FCF trend: stable':
+      'Tendencia de ingresos: al alza | tendencia de beneficios: estable | tendencia de FCF: estable',
+    'FCF is the crown jewel: rising profits should eventually show up in free cash flow.':
+      'El FCF es la joya de la corona: si los beneficios suben, debería terminar viéndose en el flujo de caja libre.',
+    'Deuda neta / Net Cash': 'Deuda neta / caja neta',
+    'Net Cash': 'caja neta',
+    'Frequent large acquisitions increase integration risk':
+      'Adquisiciones grandes y frecuentes aumentan el riesgo de integración',
+    'Acquisition-heavy': 'Intensiva en adquisiciones',
+    'debt paydown': 'amortización de deuda',
+    'cash build': 'aumento/acumulación de caja',
+    'FCF used for': 'FCF destinado a',
+    '% of FCF': '% del FCF',
+    buybacks: 'recompras',
+    dividends: 'dividendos',
+    EPS: 'BPA (beneficio por acción)',
+    'NI/EPS': 'beneficio neto / BPA'
+  }
+};
+
+const FIN_LABEL_ENTRIES = Object.entries(FINANCIAL_LABEL_EN_ES).sort(
+  (a, b) => b[0].length - a[0].length
+);
+const reverseAndSortByFromLen = (entries) =>
+  entries
+    .map(([from, to]) => [to, from])
+    .sort((a, b) => b[0].length - a[0].length);
+
+const FIN_LABEL_ENTRIES_REVERSED = reverseAndSortByFromLen(FIN_LABEL_ENTRIES);
+const METRIC_ENTRIES = Object.entries(DYNAMIC_I18N.metricNames).sort(
+  (a, b) => b[0].length - a[0].length
+);
+const METRIC_ENTRIES_REVERSED = reverseAndSortByFromLen(METRIC_ENTRIES);
+const SECTION_ENTRIES = Object.entries(DYNAMIC_I18N.sectionTitles).sort(
+  (a, b) => b[0].length - a[0].length
+);
+const SECTION_ENTRIES_REVERSED = reverseAndSortByFromLen(SECTION_ENTRIES);
+const FRAG_ENTRIES = Object.entries(DYNAMIC_I18N.fragments).sort(
+  (a, b) => b[0].length - a[0].length
+);
+const FRAG_ENTRIES_REVERSED = reverseAndSortByFromLen(FRAG_ENTRIES);
+
+function compileReplacers(entries) {
+  return entries.map(([from, to]) => {
+    const hasAlphaNum = /[A-Za-z0-9]/.test(from);
+    if (!hasAlphaNum) {
+      return {
+        replace: (text) => text.replaceAll(from, to)
+      };
+    }
+    const escaped = escapeRegExp(from);
+    const re = new RegExp(
+      `(^|[^\\p{L}\\p{N}_])(${escaped})(?=$|[^\\p{L}\\p{N}_])`,
+      'gu'
+    );
+    return {
+      replace: (text) => text.replace(re, (_, lead) => `${lead}${to}`)
+    };
+  });
+}
+
+const METRIC_REPLACERS_ES = compileReplacers(METRIC_ENTRIES);
+const METRIC_REPLACERS_EN = compileReplacers(METRIC_ENTRIES_REVERSED);
+const SECTION_REPLACERS_ES = compileReplacers(SECTION_ENTRIES);
+const SECTION_REPLACERS_EN = compileReplacers(SECTION_ENTRIES_REVERSED);
+const FRAG_REPLACERS_ES = compileReplacers(FRAG_ENTRIES);
+const FRAG_REPLACERS_EN = compileReplacers(FRAG_ENTRIES_REVERSED);
+const FIN_REPLACERS_ES = compileReplacers(FIN_LABEL_ENTRIES);
+const FIN_REPLACERS_EN = compileReplacers(FIN_LABEL_ENTRIES_REVERSED);
+
+export function localizeDynamicText(text, lang) {
+  if (!text) return text;
+  let out = normalizeSentenceText(text);
+
+  const metricReplacers =
+    lang === 'es' ? METRIC_REPLACERS_ES : METRIC_REPLACERS_EN;
+  metricReplacers.forEach((replacer) => {
+    out = replacer.replace(out);
+  });
+
+  const sectionReplacers =
+    lang === 'es' ? SECTION_REPLACERS_ES : SECTION_REPLACERS_EN;
+  sectionReplacers.forEach((replacer) => {
+    out = replacer.replace(out);
+  });
+
+  const fragmentReplacers =
+    lang === 'es' ? FRAG_REPLACERS_ES : FRAG_REPLACERS_EN;
+  fragmentReplacers.forEach((replacer) => {
+    out = replacer.replace(out);
+  });
+
+  const financialReplacers =
+    lang === 'es' ? FIN_REPLACERS_ES : FIN_REPLACERS_EN;
+  financialReplacers.forEach((replacer) => {
+    out = replacer.replace(out);
+  });
+
+  return out;
+}
+
+function parseMetricDetail(detail) {
+  if (!detail) return null;
+  const normalized = String(detail).replace(/\s+/g, ' ').trim();
+  if (!normalized) return null;
+
+  const segments = normalized
+    .split(/\s*•\s*|\s+\|\s+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+
+  if (!segments.length) return null;
+
+  const interpretationRe = /^(interpretaci[oó]n|interpretation)\s*:\s*/i;
+  let summaryMain = segments.shift() || '';
+  let summaryInterpretation = '';
+
+  const summaryInterpretationMatch = summaryMain.match(
+    /(.*?)(?:\s*[—-]\s*)?(interpretaci[oó]n|interpretation)\s*:\s*(.+)$/i
+  );
+  if (summaryInterpretationMatch) {
+    summaryMain = summaryInterpretationMatch[1]?.trim() || summaryMain;
+    summaryInterpretation = summaryInterpretationMatch[3]?.trim() || '';
+  }
+
+  const items = [];
+  segments.forEach((segment) => {
+    if (interpretationRe.test(segment) && !summaryInterpretation) {
+      summaryInterpretation = segment.replace(interpretationRe, '').trim();
+      return;
+    }
+    items.push(segment);
+  });
+
+  if (!summaryMain && items.length) {
+    summaryMain = items.shift() || '';
+  }
+
+  return {
+    summaryMain,
+    summaryInterpretation,
+    items
+  };
+}
+
+export function renderMetricDetail(detail, lang) {
+  const parsed = parseMetricDetail(detail);
+  if (!parsed) return '';
+
+  const hasStructuredDetail = parsed.items.length > 0 || parsed.summaryInterpretation;
+  if (!hasStructuredDetail) {
+    return `<div class="metric-detail">${localizeDynamicText(parsed.summaryMain, lang)}</div>`;
+  }
+
+  const summaryMain = localizeDynamicText(parsed.summaryMain, lang);
+  const summaryInterpretation = parsed.summaryInterpretation
+    ? `<span class="md-interpret">${localizeDynamicText(parsed.summaryInterpretation, lang)}</span>`
+    : '';
+  const listItems = parsed.items
+    .map((item) => {
+      const idx = item.indexOf(':');
+      if (idx <= 0) return `<li>${localizeDynamicText(item, lang)}</li>`;
+      const label = item.slice(0, idx).trim();
+      const value = item.slice(idx + 1).trim();
+      if (!value) return `<li>${localizeDynamicText(item, lang)}</li>`;
+      return `<li><span class="md-label">${localizeDynamicText(label + ':', lang)}</span> ${localizeDynamicText(value, lang)}</li>`;
+    })
+    .join('');
+
+  return `<details class="metric-detail"><summary><span class="md-kpi">${summaryMain}</span>${summaryInterpretation}</summary><ul class="md-list">${listItems}</ul></details>`;
+}
+
+function splitDetailLabelValue(detailItem) {
+  const idx = String(detailItem || '').indexOf(':');
+  if (idx <= 0) return null;
+  const label = detailItem.slice(0, idx).trim();
+  const value = detailItem.slice(idx + 1).trim();
+  if (!label || !value) return null;
+  return { label, value };
+}
+
+export function renderPrintableMetricDetail(item, lang, escapeHtml) {
+  const parsed = parseMetricDetail(item.detail || '');
+  const headline = localizeDynamicText(
+    parsed?.summaryMain || item.value || item.detail || '',
+    lang
+  );
+  const bullets = [];
+
+  if (parsed?.summaryInterpretation) {
+    bullets.push({
+      label: lang === 'es' ? 'Interpretación:' : 'Interpretation:',
+      value: localizeDynamicText(parsed.summaryInterpretation, lang)
+    });
+  }
+
+  (parsed?.items || []).forEach((entry) => {
+    const split = splitDetailLabelValue(entry);
+    if (split) {
+      bullets.push({
+        label: localizeDynamicText(split.label + ':', lang),
+        value: localizeDynamicText(split.value, lang)
+      });
+      return;
+    }
+    bullets.push({ value: localizeDynamicText(entry, lang) });
+  });
+
+  if (!parsed && item.detail) {
+    bullets.push({ value: localizeDynamicText(item.detail, lang) });
+  }
+
+  if (item.explanation) {
+    bullets.push({
+      label: lang === 'es' ? 'Datos:' : 'Data:',
+      value: localizeDynamicText(item.explanation, lang)
+    });
+  }
+
+  if (!bullets.length) {
+    bullets.push({
+      value: lang === 'es' ? 'Sin detalle adicional.' : 'No additional detail.'
+    });
+  }
+
+  const bulletHtml = bullets
+    .map((bullet) => {
+      if (!bullet.label) return `<li>${escapeHtml(bullet.value)}</li>`;
+      return `<li><strong>${escapeHtml(bullet.label)}</strong> ${escapeHtml(bullet.value)}</li>`;
+    })
+    .join('');
+
+  return {
+    headline,
+    bulletHtml
+  };
+}
+


### PR DESCRIPTION
### Motivation
- Reduce complexity and coupling in `scoring.ts` by moving large localization/label-normalization/rendering logic into a focused module so parsing/analysis stays clear and maintainable.

### Description
- Extracted financial-label normalization, canonicalization, dynamic text localization and metric-detail rendering into a new module `src/domain/metrics/scoringLocalization.ts` and exported helpers like `normalizeLabelText`, `canonicalizeFinancialLabel`, `localizeDynamicText`, `renderMetricDetail`, and `renderPrintableMetricDetail`.
- Updated `src/domain/metrics/scoring.ts` to import those helpers and to pass `currentLang` and `escapeHtml` explicitly where needed, keeping behavior identical but separating responsibilities.
- Kept parsing/analyzers in `scoring.ts` unchanged except for replacing the inlined localization code with calls to the new helpers.

### Testing
- Ran `npm test -- --runInBand` which failed due to Vitest not recognizing the `--runInBand` option (environment/CLI mismatch).
- Ran `npm test` to execute the full suite, and all tests passed: 13 test files, 62 tests (green).
- Addressed a follow-up import/export issue (`normalizeLabelText`) during the refactor and re-ran `npm test` to confirm the suite remained fully green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dd6d3079c8320b36f9953ecf33803)