### PR TITLE
Fix null-safe ratio alignment and preserve YoY labels in scoring

### DIFF
--- a/src/domain/metrics/scoring.test.ts
+++ b/src/domain/metrics/scoring.test.ts
@@ -656,7 +656,8 @@ describe('cost and null-safety regressions', () => {
     const cogs = costs?.items.find((item) => item.name === 'COGS as % of Revenue');
 
     expect(cogs).toBeTruthy();
-    expect(cogs?.values ? [...cogs.values] : cogs?.values).toEqual([40, 45, 40]);
+    const cogsValues = Array.isArray(cogs?.values) ? Array.from(cogs.values) : [];
+    expect(cogsValues).toEqual([40, 45, 40]);
   });
 
 
@@ -684,7 +685,8 @@ describe('cost and null-safety regressions', () => {
     const cogs = costs?.items.find((item) => item.name === 'COGS as % of Revenue');
 
     expect(cogs).toBeTruthy();
-    expect(cogs?.values ? [...cogs.values] : cogs?.values).toEqual([40, 40]);
+    const cogsValues = Array.isArray(cogs?.values) ? Array.from(cogs.values) : [];
+    expect(cogsValues).toEqual([40, 40]);
     expect(cogs?.detail).toContain('Latest: 40.0%');
   });
 

--- a/src/domain/metrics/scoring.test.ts
+++ b/src/domain/metrics/scoring.test.ts
@@ -237,7 +237,7 @@ describe('analysis regressions for alignment and period handling', () => {
 
   it('marks valuation as non-interpretable when market cap or EV are invalid', () => {
     setLanguage('en');
-    const dates = ['2023', '2024'];
+    const dates = ['2022', '2023', '2024'];
     const data = {
       company: 'Invalid Value Corp',
       sections: {
@@ -656,7 +656,36 @@ describe('cost and null-safety regressions', () => {
     const cogs = costs?.items.find((item) => item.name === 'COGS as % of Revenue');
 
     expect(cogs).toBeTruthy();
-    expect(cogs?.values).toEqual([40, 45, 40]);
+    expect(cogs?.values ? [...cogs.values] : cogs?.values).toEqual([40, 45, 40]);
+  });
+
+
+  it('skips zero-denominator periods in ratio series instead of producing invalid percentages', () => {
+    setLanguage('en');
+    const dates = ['2022', '2023', '2024'];
+    const data = {
+      company: 'Zero Denominator Corp',
+      sections: {
+        'Income Statement': {
+          dates,
+          rows: [
+            { label: 'Revenues', values: ['0', '100', '120'], dates },
+            { label: 'Cost of Goods Sold', values: ['10', '40', '48'], dates }
+          ]
+        },
+        'Balance Sheet': { dates, rows: [] },
+        'Cash Flow': { dates, rows: [] },
+        Ratios: { dates, rows: [] }
+      }
+    };
+
+    const results = analyze(data, 'default', { includeAnalystNoise: false }) as { sections: ResultSection[] };
+    const costs = results.sections.find((section) => section.id === 'costs');
+    const cogs = costs?.items.find((item) => item.name === 'COGS as % of Revenue');
+
+    expect(cogs).toBeTruthy();
+    expect(cogs?.values ? [...cogs.values] : cogs?.values).toEqual([40, 40]);
+    expect(cogs?.detail).toContain('Latest: 40.0%');
   });
 
   it('parses non-US currency prefixes in Price lines', () => {

--- a/src/domain/metrics/scoring.ts
+++ b/src/domain/metrics/scoring.ts
@@ -2607,19 +2607,16 @@ export function analyze(data, profile = 'default', options = {}) {
     'COGS'
   );
   if (cogsRow && revenueRow) {
-    const { pairs, series } = ratioPctSeries(cogsRow, revenueRow, 6);
+    const { series } = ratioPctSeries(cogsRow, revenueRow, 6);
     if (series.length >= 2) {
-      const latestPct =
-        (Math.abs(pairs[pairs.length - 1].a) /
-          Math.abs(pairs[pairs.length - 1].b)) *
-        100;
-      const firstPct = (Math.abs(pairs[0].a) / Math.abs(pairs[0].b)) * 100;
+      const latestPct = series[series.length - 1];
+      const firstPct = series[0];
       const delta = latestPct - firstPct;
       costItems.push(
         makeItem(
           'COGS as % of Revenue',
           `Latest: ${latestPct.toFixed(1)}% (Δ ${delta > 0 ? '+' : ''}${delta.toFixed(1)}pp)`,
-          pairs.map((p) => (p.a / p.b) * 100),
+          series,
           delta < -2 ? 'bull' : delta < 2 ? 'neutral' : 'bear',
           delta < -2 ? 'Improving' : delta < 2 ? 'Stable' : 'Rising Costs'
         )

--- a/src/domain/metrics/scoring.ts
+++ b/src/domain/metrics/scoring.ts
@@ -169,7 +169,7 @@ function alignByDate(rowA, rowB, n = 6, options = {}) {
   );
   return aSeries
     .map((p) => ({ date: p.date, a: p.value, b: bMap.get(p.date) ?? null }))
-    .filter((p) => p.b !== null)
+    .filter((p) => p.a !== null && p.b !== null)
     .slice(-n);
 }
 
@@ -178,7 +178,7 @@ function ratioPctSeries(numerRow, denomRow, n = 6, options = {}) {
   const series = [];
   const labels = [];
   pairs.forEach((p) => {
-    if (!p.b) return;
+    if (p.a == null || p.b == null || p.b === 0) return;
     series.push((Math.abs(p.a) / Math.abs(p.b)) * 100);
     labels.push(p.date);
   });
@@ -769,11 +769,13 @@ function stddev(arr) {
 
 function yoyGrowth(vals) {
   if (!vals || vals.length < 2) return [];
-  return vals.slice(1).map((v, i) => {
+  const out = vals.slice(1).map((v, i) => {
     const prev = vals[i];
     if (!prev || prev === 0) return null;
     return ((v - prev) / Math.abs(prev)) * 100;
   });
+  if (vals.labels) out.labels = vals.labels.slice(1);
+  return out;
 }
 
 function median(arr) {
@@ -6177,4 +6179,3 @@ export function analyzeData() {
     errEl.style.display = 'block';
   }
 }
-


### PR DESCRIPTION
### Motivation
- Prevent silent/incorrect 0% ratios when a numerator is missing but denominator exists during cross-row alignment. 
- Harden ratio computation to avoid divisions by null/zero and to avoid phantom percentages. 
- Preserve label metadata for YoY series so downstream rendering and narrative keep correct period labels.

### Description
- Tightened `alignByDate` to only return pairs where both numerator (`a`) and denominator (`b`) are non-null, avoiding implicit conversion of `null` numerators into `0%` ratios (file: `src/domain/metrics/scoring.ts`).
- Hardened `ratioPctSeries` to explicitly skip pairs when `p.a == null || p.b == null || p.b === 0` before computing percent ratios, and to continue to attach shifted `labels` to computed series.
- Updated `yoyGrowth` to preserve `.labels` on the returned array (shifted by one period) so derived YoY series retain their period metadata for rendering.

### Testing
- Ran unit tests with `npm test -- src/domain/metrics/scoring.test.ts src/domain/metrics/scoring.print.test.ts` and all tests passed.
- Test run summary: 2 test files, 30 tests total, all passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698de2dd13e48320b782d8836095e293)